### PR TITLE
Add the --map_binary_to_string compat flag to update-to-latest.sh.

### DIFF
--- a/scripts/update-to-latest.sh
+++ b/scripts/update-to-latest.sh
@@ -37,8 +37,8 @@ commit_rev=$(echo "$commit_pos_line" | grep -E -o "\d+")
 
 # generate json from pdl
 convert_script="$protocol_repo_path/scripts/inspector_protocol/convert_protocol_to_json.py"
-python "$convert_script" "$protocol_repo_path/pdl/browser_protocol.pdl" "$protocol_repo_path/json/browser_protocol.json"
-python "$convert_script" "$protocol_repo_path/pdl/js_protocol.pdl" "$protocol_repo_path/json/js_protocol.json"
+python "$convert_script" --map_binary_to_string=true "$protocol_repo_path/pdl/browser_protocol.pdl" "$protocol_repo_path/json/browser_protocol.json"
+python "$convert_script" --map_binary_to_string=true "$protocol_repo_path/pdl/js_protocol.pdl" "$protocol_repo_path/json/js_protocol.json"
 # The conversion script leaves json files next to the pdl's. Because reasons.
 rm -f "$protocol_repo_path"/pdl/*.json
 


### PR DESCRIPTION
I added this flag in https://chromium-review.googlesource.com/c/deps/inspector_protocol/+/1285695. It makes it so that protocol binary types in .pdl files are represented as string in the .json protocol description files. This means that it's up to the client code to handle the base64 decoding and encoding. On the wire, it's a JSON string either way.