### PR TITLE
Update the template to include feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/stop--file-a-report-or-feature-request-on-crbug-com.md
+++ b/.github/ISSUE_TEMPLATE/stop--file-a-report-or-feature-request-on-crbug-com.md
@@ -1,6 +1,6 @@
 ---
-name: STOP, file a report on crbug.com
-about: STOP, file a report on crbug.com
+name: STOP, file a bug report or a feature request on crbug.com
+about: STOP, file a bug report or a feature request on crbug.com
 title: ''
 labels: ''
 assignees: ''


### PR DESCRIPTION
I've come here to file a feature request. I'm not surprised to see a no-discussion style issue template here, redirecting me to CRbug, but I find it odd that feature requests are not mentioned once in it. Are feature requests not accepted for CDP? Only bug reports? I filed my feature request with CRbug anyway, but it's really not clear what is the stance on those here, or there. The name is CRbug after all. Do I have to get hired by Google, befriend the people on the CDP team, work towards a transfer to the CDP team and then pitch my idea to the CDP PM? I'm going to go ahead and assume that no, you do in fact also accept feature requests, and to save some future me's some confusion, I provide a patch for the issue template to communicate that.