### PR TITLE
Fix license reference to use proper format

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The Chrome DevTools Protocol JSON",
   "repository": "https://github.com/ChromeDevTools/devtools-protocol",
   "author": "The Chromium Authors",
-  "license": "SEE LICENSE IN https://chromium.googlesource.com/chromium/src/+/master/LICENSE",
+  "license": "LicenseRef-LICENSE",
   "bugs": {
     "url": "https://github.com/ChromeDevTools/devtools-protocol/issues"
   },


### PR DESCRIPTION
NPM suggests to use the `LicenseRef` format for licenses that are
part of the repository (by having a top-level LICENSE file) [1].

Fixes #177

[1]: https://github.com/npm/npm/issues/8795#issuecomment-119760485