### PR TITLE
Validate JSON files using protocol-schema.d.ts

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.510771",
   "license": "SEE LICENSE IN https://chromium.googlesource.com/chromium/src/+/master/LICENSE",
   "scripts": {
-    "build-protocol-dts": "ts-node protocol-dts-generator.ts",
+    "build-protocol-dts": "ts-node --compiler ttypescript protocol-dts-generator.ts",
     "type-check": "tsc -p tsconfig.json",
     "changelog": "node generate-changelog.js"
   },
@@ -11,7 +11,9 @@
     "just-diff": "^2.1.0",
     "obj-list-diff": "^1.0.0",
     "simple-git": "^1.75.0",
-    "ts-node": "^7.0.0",
-    "typescript": "3.0.1"
+    "ts-node": "^8.8.2",
+    "ttypescript": "^1.5.10",
+    "typescript": "^3.8.3",
+    "typescript-is": "^0.15.0"
   }
 }

--- a/scripts/protocol-dts-generator.ts
+++ b/scripts/protocol-dts-generator.ts
@@ -1,10 +1,10 @@
 import * as fs from 'fs'
 import * as path from 'path'
+import { assertType } from 'typescript-is';
 import {IProtocol, Protocol as P} from './protocol-schema'
 
-// TODO: @noj validate this via https://github.com/andischerer/typescript-json-typesafe against protocol-schema.d.ts
-const jsProtocol: IProtocol = require('../json/js_protocol.json')
-const browserProtocol: IProtocol = require('../json/browser_protocol.json')
+const jsProtocol = assertType<IProtocol>(require('../json/js_protocol.json'))
+const browserProtocol = assertType<IProtocol>(require('../json/browser_protocol.json'))
 const protocolDomains: P.Domain[] = jsProtocol.domains.concat(browserProtocol.domains)
 
 let numIndents = 0

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -6,6 +6,9 @@
         "target": "ES2017",
         "typeRoots": ["node_modules/@types"],
         "resolveJsonModule": true,
+        "plugins": [
+            { "transform": "typescript-is/lib/transform-inline/transformer" }
+        ]
     },
     "include": [
         "protocol-dts-generator.ts",


### PR DESCRIPTION
I changed the typescript compiler configuration in `scripts/` to use a transformer provided by [`typescript-is`](https://github.com/woutervh-/typescript-is) that will let us assert that our JSON protocol files are valid compared aganst `protocol-schema`.

@nojvek (assuming you're the `@noj` mentioned in the source code)