### PR TITLE
Pull out inline enums as types in protocol.d.ts

### DIFF
--- a/scripts/protocol-dts-generator.ts
+++ b/scripts/protocol-dts-generator.ts
@@ -59,7 +59,7 @@ const fixCamelCase = (name: string): string => {
 
 
 const emitEnum = (enumName: string, enumValues: string[]) => {
-    emitOpenBlock(`export enum ${enumName}`);
+    emitOpenBlock(`export const enum ${enumName}`);
     enumValues.forEach(value => {
       emitLine(`${fixCamelCase(value)} = '${value}',`);
     });
@@ -114,13 +114,8 @@ const isPropertyInlineEnum = (prop: P.ProtocolType): boolean => {
 const getPropertyDef = (interfaceName: string, prop: P.PropertyType): string => {
     // Quote key if it has a . in it.
     const propName = prop.name.includes('.') ? `'${prop.name}'` : prop.name
-      let type: string;
-      if (isPropertyInlineEnum(prop)) {
-        type = interfaceName + toTitleCase(prop.name);
-      } else {
-        type = getPropertyType(interfaceName, prop);
-      }
-      return `${propName}${prop.optional ? '?' : ''}: ${type}`;
+    const type = getPropertyType(interfaceName, prop);
+    return `${propName}${prop.optional ? '?' : ''}: ${type}`;
 };
 
 const getPropertyType = (interfaceName: string, prop: P.ProtocolType): string  => {
@@ -149,10 +144,16 @@ const getPropertyType = (interfaceName: string, prop: P.ProtocolType): string  =
 }
 
 const emitProperty = (interfaceName: string, prop: P.PropertyType) => {
-    emitDescription(prop.description)
-    emitLine(`${getPropertyDef(interfaceName, prop)};`)
+  let description = prop.description;
+  if (isPropertyInlineEnum(prop)) {
+    const enumName = interfaceName + toTitleCase(prop.name);
+    description = `${description || ''} (${enumName} enum)`;
+  }
+
+  emitDescription(description)
+  emitLine(`${getPropertyDef(interfaceName, prop)};`)
 }
- 
+
 
 const emitInlineEnumForDomainType = (type: P.DomainType) => {
   if (type.type === 'object') {

--- a/types/protocol.d.ts
+++ b/types/protocol.d.ts
@@ -11,7 +11,7 @@ export namespace Protocol {
      */
     export namespace Console {
 
-        export enum ConsoleMessageSource {
+        export const enum ConsoleMessageSource {
             XML = 'xml',
             Javascript = 'javascript',
             Network = 'network',
@@ -25,7 +25,7 @@ export namespace Protocol {
             Worker = 'worker',
         }
 
-        export enum ConsoleMessageLevel {
+        export const enum ConsoleMessageLevel {
             Log = 'log',
             Warning = 'warning',
             Error = 'error',
@@ -38,13 +38,13 @@ export namespace Protocol {
          */
         export interface ConsoleMessage {
             /**
-             * Message source.
+             * Message source. (ConsoleMessageSource enum)
              */
-            source: ConsoleMessageSource;
+            source: ('xml' | 'javascript' | 'network' | 'console-api' | 'storage' | 'appcache' | 'rendering' | 'security' | 'other' | 'deprecation' | 'worker');
             /**
-             * Message severity.
+             * Message severity. (ConsoleMessageLevel enum)
              */
-            level: ConsoleMessageLevel;
+            level: ('log' | 'warning' | 'error' | 'debug' | 'info');
             /**
              * Message text.
              */
@@ -154,7 +154,7 @@ export namespace Protocol {
             returnValue?: Runtime.RemoteObject;
         }
 
-        export enum ScopeType {
+        export const enum ScopeType {
             Global = 'global',
             Local = 'local',
             With = 'with',
@@ -172,9 +172,9 @@ export namespace Protocol {
          */
         export interface Scope {
             /**
-             * Scope type.
+             * Scope type. (ScopeType enum)
              */
-            type: ScopeType;
+            type: ('global' | 'local' | 'with' | 'closure' | 'catch' | 'block' | 'script' | 'eval' | 'module' | 'wasm-expression-stack');
             /**
              * Object representing the scope. For `global` and `with` scopes it represents the actual
              * object; for the rest of the scopes, it is artificial transient object enumerating scope
@@ -206,7 +206,7 @@ export namespace Protocol {
             lineContent: string;
         }
 
-        export enum BreakLocationType {
+        export const enum BreakLocationType {
             DebuggerStatement = 'debuggerStatement',
             Call = 'call',
             Return = 'return',
@@ -225,7 +225,10 @@ export namespace Protocol {
              * Column number in the script (0-based).
              */
             columnNumber?: integer;
-            type?: BreakLocationType;
+            /**
+             *  (BreakLocationType enum)
+             */
+            type?: ('debuggerStatement' | 'call' | 'return');
         }
 
         /**
@@ -233,7 +236,7 @@ export namespace Protocol {
          */
         export type ScriptLanguage = ('JavaScript' | 'WebAssembly');
 
-        export enum DebugSymbolsType {
+        export const enum DebugSymbolsType {
             None = 'None',
             SourceMap = 'SourceMap',
             EmbeddedDWARF = 'EmbeddedDWARF',
@@ -245,16 +248,16 @@ export namespace Protocol {
          */
         export interface DebugSymbols {
             /**
-             * Type of the debug symbols.
+             * Type of the debug symbols. (DebugSymbolsType enum)
              */
-            type: DebugSymbolsType;
+            type: ('None' | 'SourceMap' | 'EmbeddedDWARF' | 'ExternalDWARF');
             /**
              * URL of the external symbol source.
              */
             externalURL?: string;
         }
 
-        export enum ContinueToLocationRequestTargetCallFrames {
+        export const enum ContinueToLocationRequestTargetCallFrames {
             Any = 'any',
             Current = 'current',
         }
@@ -264,7 +267,10 @@ export namespace Protocol {
              * Location to continue to.
              */
             location: Location;
-            targetCallFrames?: ContinueToLocationRequestTargetCallFrames;
+            /**
+             *  (ContinueToLocationRequestTargetCallFrames enum)
+             */
+            targetCallFrames?: ('any' | 'current');
         }
 
         export interface EnableRequest {
@@ -540,16 +546,16 @@ export namespace Protocol {
             actualLocation: Location;
         }
 
-        export enum SetInstrumentationBreakpointRequestInstrumentation {
+        export const enum SetInstrumentationBreakpointRequestInstrumentation {
             BeforeScriptExecution = 'beforeScriptExecution',
             BeforeScriptWithSourceMapExecution = 'beforeScriptWithSourceMapExecution',
         }
 
         export interface SetInstrumentationBreakpointRequest {
             /**
-             * Instrumentation name.
+             * Instrumentation name. (SetInstrumentationBreakpointRequestInstrumentation enum)
              */
-            instrumentation: SetInstrumentationBreakpointRequestInstrumentation;
+            instrumentation: ('beforeScriptExecution' | 'beforeScriptWithSourceMapExecution');
         }
 
         export interface SetInstrumentationBreakpointResponse {
@@ -625,7 +631,7 @@ export namespace Protocol {
             active: boolean;
         }
 
-        export enum SetPauseOnExceptionsRequestState {
+        export const enum SetPauseOnExceptionsRequestState {
             None = 'none',
             Uncaught = 'uncaught',
             All = 'all',
@@ -633,9 +639,9 @@ export namespace Protocol {
 
         export interface SetPauseOnExceptionsRequest {
             /**
-             * Pause on exceptions mode.
+             * Pause on exceptions mode. (SetPauseOnExceptionsRequestState enum)
              */
-            state: SetPauseOnExceptionsRequestState;
+            state: ('none' | 'uncaught' | 'all');
         }
 
         export interface SetReturnValueRequest {
@@ -733,7 +739,7 @@ export namespace Protocol {
             location: Location;
         }
 
-        export enum PausedEventReason {
+        export const enum PausedEventReason {
             Ambiguous = 'ambiguous',
             Assert = 'assert',
             DebugCommand = 'debugCommand',
@@ -756,9 +762,9 @@ export namespace Protocol {
              */
             callFrames: CallFrame[];
             /**
-             * Pause reason.
+             * Pause reason. (PausedEventReason enum)
              */
-            reason: PausedEventReason;
+            reason: ('ambiguous' | 'assert' | 'debugCommand' | 'DOM' | 'EventListener' | 'exception' | 'instrumentation' | 'OOM' | 'other' | 'promiseRejection' | 'XHR');
             /**
              * Object containing break-specific auxiliary properties.
              */
@@ -1429,7 +1435,7 @@ export namespace Protocol {
          */
         export type UnserializableValue = string;
 
-        export enum RemoteObjectType {
+        export const enum RemoteObjectType {
             Object = 'object',
             Function = 'function',
             Undefined = 'undefined',
@@ -1441,7 +1447,7 @@ export namespace Protocol {
             Wasm = 'wasm',
         }
 
-        export enum RemoteObjectSubtype {
+        export const enum RemoteObjectSubtype {
             Array = 'array',
             Null = 'null',
             Node = 'node',
@@ -1472,13 +1478,13 @@ export namespace Protocol {
          */
         export interface RemoteObject {
             /**
-             * Object type.
+             * Object type. (RemoteObjectType enum)
              */
-            type: RemoteObjectType;
+            type: ('object' | 'function' | 'undefined' | 'string' | 'number' | 'boolean' | 'symbol' | 'bigint' | 'wasm');
             /**
-             * Object subtype hint. Specified for `object` or `wasm` type values only.
+             * Object subtype hint. Specified for `object` or `wasm` type values only. (RemoteObjectSubtype enum)
              */
-            subtype?: RemoteObjectSubtype;
+            subtype?: ('array' | 'null' | 'node' | 'regexp' | 'date' | 'map' | 'set' | 'weakmap' | 'weakset' | 'iterator' | 'generator' | 'error' | 'proxy' | 'promise' | 'typedarray' | 'arraybuffer' | 'dataview' | 'i32' | 'i64' | 'f32' | 'f64' | 'v128' | 'anyref');
             /**
              * Object class (constructor) name. Specified for `object` type values only.
              */
@@ -1521,7 +1527,7 @@ export namespace Protocol {
             bodyGetterId?: RemoteObjectId;
         }
 
-        export enum ObjectPreviewType {
+        export const enum ObjectPreviewType {
             Object = 'object',
             Function = 'function',
             Undefined = 'undefined',
@@ -1532,7 +1538,7 @@ export namespace Protocol {
             Bigint = 'bigint',
         }
 
-        export enum ObjectPreviewSubtype {
+        export const enum ObjectPreviewSubtype {
             Array = 'array',
             Null = 'null',
             Node = 'node',
@@ -1552,13 +1558,13 @@ export namespace Protocol {
          */
         export interface ObjectPreview {
             /**
-             * Object type.
+             * Object type. (ObjectPreviewType enum)
              */
-            type: ObjectPreviewType;
+            type: ('object' | 'function' | 'undefined' | 'string' | 'number' | 'boolean' | 'symbol' | 'bigint');
             /**
-             * Object subtype hint. Specified for `object` type values only.
+             * Object subtype hint. Specified for `object` type values only. (ObjectPreviewSubtype enum)
              */
-            subtype?: ObjectPreviewSubtype;
+            subtype?: ('array' | 'null' | 'node' | 'regexp' | 'date' | 'map' | 'set' | 'weakmap' | 'weakset' | 'iterator' | 'generator' | 'error');
             /**
              * String representation of the object.
              */
@@ -1577,7 +1583,7 @@ export namespace Protocol {
             entries?: EntryPreview[];
         }
 
-        export enum PropertyPreviewType {
+        export const enum PropertyPreviewType {
             Object = 'object',
             Function = 'function',
             Undefined = 'undefined',
@@ -1589,7 +1595,7 @@ export namespace Protocol {
             Bigint = 'bigint',
         }
 
-        export enum PropertyPreviewSubtype {
+        export const enum PropertyPreviewSubtype {
             Array = 'array',
             Null = 'null',
             Node = 'node',
@@ -1610,9 +1616,9 @@ export namespace Protocol {
              */
             name: string;
             /**
-             * Object type. Accessor means that the property itself is an accessor property.
+             * Object type. Accessor means that the property itself is an accessor property. (PropertyPreviewType enum)
              */
-            type: PropertyPreviewType;
+            type: ('object' | 'function' | 'undefined' | 'string' | 'number' | 'boolean' | 'symbol' | 'accessor' | 'bigint');
             /**
              * User-friendly property value string.
              */
@@ -1622,9 +1628,9 @@ export namespace Protocol {
              */
             valuePreview?: ObjectPreview;
             /**
-             * Object subtype hint. Specified for `object` type values only.
+             * Object subtype hint. Specified for `object` type values only. (PropertyPreviewSubtype enum)
              */
-            subtype?: PropertyPreviewSubtype;
+            subtype?: ('array' | 'null' | 'node' | 'regexp' | 'date' | 'map' | 'set' | 'weakmap' | 'weakset' | 'iterator' | 'generator' | 'error');
         }
 
         export interface EntryPreview {
@@ -2265,7 +2271,7 @@ export namespace Protocol {
             executionContextId: ExecutionContextId;
         }
 
-        export enum ConsoleAPICalledEventType {
+        export const enum ConsoleAPICalledEventType {
             Log = 'log',
             Debug = 'debug',
             Info = 'info',
@@ -2291,9 +2297,9 @@ export namespace Protocol {
          */
         export interface ConsoleAPICalledEvent {
             /**
-             * Type of the call.
+             * Type of the call. (ConsoleAPICalledEventType enum)
              */
-            type: ConsoleAPICalledEventType;
+            type: ('log' | 'debug' | 'info' | 'error' | 'warning' | 'dir' | 'dirxml' | 'table' | 'trace' | 'clear' | 'startGroup' | 'startGroupCollapsed' | 'endGroup' | 'assert' | 'profile' | 'profileEnd' | 'count' | 'timeEnd');
             /**
              * Call arguments.
              */
@@ -2604,7 +2610,7 @@ export namespace Protocol {
 
     export namespace Animation {
 
-        export enum AnimationType {
+        export const enum AnimationType {
             CSSTransition = 'CSSTransition',
             CSSAnimation = 'CSSAnimation',
             WebAnimation = 'WebAnimation',
@@ -2643,9 +2649,9 @@ export namespace Protocol {
              */
             currentTime: number;
             /**
-             * Animation type of `Animation`.
+             * Animation type of `Animation`. (AnimationType enum)
              */
-            type: AnimationType;
+            type: ('CSSTransition' | 'CSSAnimation' | 'WebAnimation');
             /**
              * `Animation`'s source animation node.
              */
@@ -3106,7 +3112,7 @@ export namespace Protocol {
             details: InspectorIssueDetails;
         }
 
-        export enum GetEncodedResponseRequestEncoding {
+        export const enum GetEncodedResponseRequestEncoding {
             Webp = 'webp',
             Jpeg = 'jpeg',
             Png = 'png',
@@ -3118,9 +3124,9 @@ export namespace Protocol {
              */
             requestId: Network.RequestId;
             /**
-             * The encoding to use.
+             * The encoding to use. (GetEncodedResponseRequestEncoding enum)
              */
-            encoding: GetEncodedResponseRequestEncoding;
+            encoding: ('webp' | 'jpeg' | 'png');
             /**
              * The quality of the encoding (0-1). (defaults to 1)
              */
@@ -3387,7 +3393,7 @@ export namespace Protocol {
             browserContextId?: BrowserContextID;
         }
 
-        export enum SetDownloadBehaviorRequestBehavior {
+        export const enum SetDownloadBehaviorRequestBehavior {
             Deny = 'deny',
             Allow = 'allow',
             AllowAndName = 'allowAndName',
@@ -3398,9 +3404,9 @@ export namespace Protocol {
             /**
              * Whether to allow all or deny all download requests, or use default Chrome behavior if
              * available (otherwise deny). |allowAndName| allows download and names files according to
-             * their dowmload guids.
+             * their dowmload guids. (SetDownloadBehaviorRequestBehavior enum)
              */
-            behavior: SetDownloadBehaviorRequestBehavior;
+            behavior: ('deny' | 'allow' | 'allowAndName' | 'default');
             /**
              * BrowserContext to set download behavior. When omitted, default browser context is used.
              */
@@ -3855,7 +3861,7 @@ export namespace Protocol {
             range?: SourceRange;
         }
 
-        export enum CSSMediaSource {
+        export const enum CSSMediaSource {
             MediaRule = 'mediaRule',
             ImportRule = 'importRule',
             LinkedSheet = 'linkedSheet',
@@ -3874,9 +3880,9 @@ export namespace Protocol {
              * Source of the media query: "mediaRule" if specified by a @media rule, "importRule" if
              * specified by an @import rule, "linkedSheet" if specified by a "media" attribute in a linked
              * stylesheet's LINK tag, "inlineSheet" if specified by a "media" attribute in an inline
-             * stylesheet's STYLE tag.
+             * stylesheet's STYLE tag. (CSSMediaSource enum)
              */
-            source: CSSMediaSource;
+            source: ('mediaRule' | 'importRule' | 'linkedSheet' | 'inlineSheet');
             /**
              * URL of the document containing the media query description.
              */
@@ -6457,7 +6463,7 @@ export namespace Protocol {
      */
     export namespace Emulation {
 
-        export enum ScreenOrientationType {
+        export const enum ScreenOrientationType {
             PortraitPrimary = 'portraitPrimary',
             PortraitSecondary = 'portraitSecondary',
             LandscapePrimary = 'landscapePrimary',
@@ -6469,9 +6475,9 @@ export namespace Protocol {
          */
         export interface ScreenOrientation {
             /**
-             * Orientation type.
+             * Orientation type. (ScreenOrientationType enum)
              */
-            type: ScreenOrientationType;
+            type: ('portraitPrimary' | 'portraitSecondary' | 'landscapePrimary' | 'landscapeSecondary');
             /**
              * Orientation angle.
              */
@@ -6608,7 +6614,7 @@ export namespace Protocol {
             disabled: boolean;
         }
 
-        export enum SetEmitTouchEventsForMouseRequestConfiguration {
+        export const enum SetEmitTouchEventsForMouseRequestConfiguration {
             Mobile = 'mobile',
             Desktop = 'desktop',
         }
@@ -6619,9 +6625,9 @@ export namespace Protocol {
              */
             enabled: boolean;
             /**
-             * Touch/gesture events configuration. Default: current platform.
+             * Touch/gesture events configuration. Default: current platform. (SetEmitTouchEventsForMouseRequestConfiguration enum)
              */
-            configuration?: SetEmitTouchEventsForMouseRequestConfiguration;
+            configuration?: ('mobile' | 'desktop');
         }
 
         export interface SetEmulatedMediaRequest {
@@ -6635,7 +6641,7 @@ export namespace Protocol {
             features?: MediaFeature[];
         }
 
-        export enum SetEmulatedVisionDeficiencyRequestType {
+        export const enum SetEmulatedVisionDeficiencyRequestType {
             None = 'none',
             Achromatopsia = 'achromatopsia',
             BlurredVision = 'blurredVision',
@@ -6646,9 +6652,9 @@ export namespace Protocol {
 
         export interface SetEmulatedVisionDeficiencyRequest {
             /**
-             * Vision deficiency to emulate.
+             * Vision deficiency to emulate. (SetEmulatedVisionDeficiencyRequestType enum)
              */
-            type: SetEmulatedVisionDeficiencyRequestType;
+            type: ('none' | 'achromatopsia' | 'blurredVision' | 'deuteranopia' | 'protanopia' | 'tritanopia');
         }
 
         export interface SetGeolocationOverrideRequest {
@@ -6780,7 +6786,7 @@ export namespace Protocol {
      */
     export namespace HeadlessExperimental {
 
-        export enum ScreenshotParamsFormat {
+        export const enum ScreenshotParamsFormat {
             Jpeg = 'jpeg',
             Png = 'png',
         }
@@ -6790,9 +6796,9 @@ export namespace Protocol {
          */
         export interface ScreenshotParams {
             /**
-             * Image compression format (defaults to png).
+             * Image compression format (defaults to png). (ScreenshotParamsFormat enum)
              */
-            format?: ScreenshotParamsFormat;
+            format?: ('jpeg' | 'png');
             /**
              * Compression quality from range [0..100] (jpeg only).
              */
@@ -6978,7 +6984,7 @@ export namespace Protocol {
             multiEntry: boolean;
         }
 
-        export enum KeyType {
+        export const enum KeyType {
             Number = 'number',
             String = 'string',
             Date = 'date',
@@ -6990,9 +6996,9 @@ export namespace Protocol {
          */
         export interface Key {
             /**
-             * Key type.
+             * Key type. (KeyType enum)
              */
-            type: KeyType;
+            type: ('number' | 'string' | 'date' | 'array');
             /**
              * Number value.
              */
@@ -7051,7 +7057,7 @@ export namespace Protocol {
             value: Runtime.RemoteObject;
         }
 
-        export enum KeyPathType {
+        export const enum KeyPathType {
             Null = 'null',
             String = 'string',
             Array = 'array',
@@ -7062,9 +7068,9 @@ export namespace Protocol {
          */
         export interface KeyPath {
             /**
-             * Key path type.
+             * Key path type. (KeyPathType enum)
              */
-            type: KeyPathType;
+            type: ('null' | 'string' | 'array');
             /**
              * String value.
              */
@@ -7257,7 +7263,7 @@ export namespace Protocol {
          */
         export type TimeSinceEpoch = number;
 
-        export enum DispatchKeyEventRequestType {
+        export const enum DispatchKeyEventRequestType {
             KeyDown = 'keyDown',
             KeyUp = 'keyUp',
             RawKeyDown = 'rawKeyDown',
@@ -7266,9 +7272,9 @@ export namespace Protocol {
 
         export interface DispatchKeyEventRequest {
             /**
-             * Type of the key event.
+             * Type of the key event. (DispatchKeyEventRequestType enum)
              */
-            type: DispatchKeyEventRequestType;
+            type: ('keyDown' | 'keyUp' | 'rawKeyDown' | 'char');
             /**
              * Bit field representing pressed modifier keys. Alt=1, Ctrl=2, Meta/Command=4, Shift=8
              * (default: 0).
@@ -7335,23 +7341,23 @@ export namespace Protocol {
             text: string;
         }
 
-        export enum DispatchMouseEventRequestType {
+        export const enum DispatchMouseEventRequestType {
             MousePressed = 'mousePressed',
             MouseReleased = 'mouseReleased',
             MouseMoved = 'mouseMoved',
             MouseWheel = 'mouseWheel',
         }
 
-        export enum DispatchMouseEventRequestPointerType {
+        export const enum DispatchMouseEventRequestPointerType {
             Mouse = 'mouse',
             Pen = 'pen',
         }
 
         export interface DispatchMouseEventRequest {
             /**
-             * Type of the mouse event.
+             * Type of the mouse event. (DispatchMouseEventRequestType enum)
              */
-            type: DispatchMouseEventRequestType;
+            type: ('mousePressed' | 'mouseReleased' | 'mouseMoved' | 'mouseWheel');
             /**
              * X coordinate of the event relative to the main frame's viewport in CSS pixels.
              */
@@ -7392,12 +7398,12 @@ export namespace Protocol {
              */
             deltaY?: number;
             /**
-             * Pointer type (default: "mouse").
+             * Pointer type (default: "mouse"). (DispatchMouseEventRequestPointerType enum)
              */
-            pointerType?: DispatchMouseEventRequestPointerType;
+            pointerType?: ('mouse' | 'pen');
         }
 
-        export enum DispatchTouchEventRequestType {
+        export const enum DispatchTouchEventRequestType {
             TouchStart = 'touchStart',
             TouchEnd = 'touchEnd',
             TouchMove = 'touchMove',
@@ -7407,9 +7413,9 @@ export namespace Protocol {
         export interface DispatchTouchEventRequest {
             /**
              * Type of the touch event. TouchEnd and TouchCancel must not contain any touch points, while
-             * TouchStart and TouchMove must contains at least one.
+             * TouchStart and TouchMove must contains at least one. (DispatchTouchEventRequestType enum)
              */
-            type: DispatchTouchEventRequestType;
+            type: ('touchStart' | 'touchEnd' | 'touchMove' | 'touchCancel');
             /**
              * Active touch points on the touch device. One event per any changed point (compared to
              * previous touch event in a sequence) is generated, emulating pressing/moving/releasing points
@@ -7427,7 +7433,7 @@ export namespace Protocol {
             timestamp?: TimeSinceEpoch;
         }
 
-        export enum EmulateTouchFromMouseEventRequestType {
+        export const enum EmulateTouchFromMouseEventRequestType {
             MousePressed = 'mousePressed',
             MouseReleased = 'mouseReleased',
             MouseMoved = 'mouseMoved',
@@ -7436,9 +7442,9 @@ export namespace Protocol {
 
         export interface EmulateTouchFromMouseEventRequest {
             /**
-             * Type of the mouse event.
+             * Type of the mouse event. (EmulateTouchFromMouseEventRequestType enum)
              */
-            type: EmulateTouchFromMouseEventRequestType;
+            type: ('mousePressed' | 'mouseReleased' | 'mouseMoved' | 'mouseWheel');
             /**
              * X coordinate of the mouse pointer in DIP.
              */
@@ -7609,7 +7615,7 @@ export namespace Protocol {
          */
         export type SnapshotId = string;
 
-        export enum ScrollRectType {
+        export const enum ScrollRectType {
             RepaintsOnScroll = 'RepaintsOnScroll',
             TouchEventHandler = 'TouchEventHandler',
             WheelEventHandler = 'WheelEventHandler',
@@ -7624,9 +7630,9 @@ export namespace Protocol {
              */
             rect: DOM.Rect;
             /**
-             * Reason for rectangle to force scrolling on the main thread
+             * Reason for rectangle to force scrolling on the main thread (ScrollRectType enum)
              */
-            type: ScrollRectType;
+            type: ('RepaintsOnScroll' | 'TouchEventHandler' | 'WheelEventHandler');
         }
 
         /**
@@ -7888,7 +7894,7 @@ export namespace Protocol {
      */
     export namespace Log {
 
-        export enum LogEntrySource {
+        export const enum LogEntrySource {
             XML = 'xml',
             Javascript = 'javascript',
             Network = 'network',
@@ -7904,7 +7910,7 @@ export namespace Protocol {
             Other = 'other',
         }
 
-        export enum LogEntryLevel {
+        export const enum LogEntryLevel {
             Verbose = 'verbose',
             Info = 'info',
             Warning = 'warning',
@@ -7916,13 +7922,13 @@ export namespace Protocol {
          */
         export interface LogEntry {
             /**
-             * Log entry source.
+             * Log entry source. (LogEntrySource enum)
              */
-            source: LogEntrySource;
+            source: ('xml' | 'javascript' | 'network' | 'storage' | 'appcache' | 'rendering' | 'security' | 'deprecation' | 'worker' | 'violation' | 'intervention' | 'recommendation' | 'other');
             /**
-             * Log entry severity.
+             * Log entry severity. (LogEntryLevel enum)
              */
-            level: LogEntryLevel;
+            level: ('verbose' | 'info' | 'warning' | 'error');
             /**
              * Logged text.
              */
@@ -7957,7 +7963,7 @@ export namespace Protocol {
             args?: Runtime.RemoteObject[];
         }
 
-        export enum ViolationSettingName {
+        export const enum ViolationSettingName {
             LongTask = 'longTask',
             LongLayout = 'longLayout',
             BlockedEvent = 'blockedEvent',
@@ -7972,9 +7978,9 @@ export namespace Protocol {
          */
         export interface ViolationSetting {
             /**
-             * Violation type.
+             * Violation type. (ViolationSettingName enum)
              */
-            name: ViolationSettingName;
+            name: ('longTask' | 'longLayout' | 'blockedEvent' | 'blockedParser' | 'discouragedAPIUse' | 'handler' | 'recurringHandler');
             /**
              * Time threshold to trigger upon.
              */
@@ -8248,7 +8254,7 @@ export namespace Protocol {
          */
         export type ResourcePriority = ('VeryLow' | 'Low' | 'Medium' | 'High' | 'VeryHigh');
 
-        export enum RequestReferrerPolicy {
+        export const enum RequestReferrerPolicy {
             UnsafeUrl = 'unsafe-url',
             NoReferrerWhenDowngrade = 'no-referrer-when-downgrade',
             NoReferrer = 'no-referrer',
@@ -8296,9 +8302,9 @@ export namespace Protocol {
              */
             initialPriority: ResourcePriority;
             /**
-             * The referrer policy of the request, as defined in https://www.w3.org/TR/referrer-policy/
+             * The referrer policy of the request, as defined in https://www.w3.org/TR/referrer-policy/ (RequestReferrerPolicy enum)
              */
-            referrerPolicy: RequestReferrerPolicy;
+            referrerPolicy: ('unsafe-url' | 'no-referrer-when-downgrade' | 'no-referrer' | 'origin' | 'origin-when-cross-origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin');
             /**
              * Whether is loaded via link preload.
              */
@@ -8579,7 +8585,7 @@ export namespace Protocol {
             bodySize: number;
         }
 
-        export enum InitiatorType {
+        export const enum InitiatorType {
             Parser = 'parser',
             Script = 'script',
             Preload = 'preload',
@@ -8592,9 +8598,9 @@ export namespace Protocol {
          */
         export interface Initiator {
             /**
-             * Type of this initiator.
+             * Type of this initiator. (InitiatorType enum)
              */
-            type: InitiatorType;
+            type: ('parser' | 'script' | 'preload' | 'SignedExchange' | 'other');
             /**
              * Initiator JavaScript stack trace, set for Script only.
              */
@@ -8752,7 +8758,7 @@ export namespace Protocol {
             priority?: CookiePriority;
         }
 
-        export enum AuthChallengeSource {
+        export const enum AuthChallengeSource {
             Server = 'Server',
             Proxy = 'Proxy',
         }
@@ -8762,9 +8768,9 @@ export namespace Protocol {
          */
         export interface AuthChallenge {
             /**
-             * Source of the authentication challenge.
+             * Source of the authentication challenge. (AuthChallengeSource enum)
              */
-            source?: AuthChallengeSource;
+            source?: ('Server' | 'Proxy');
             /**
              * Origin of the challenger.
              */
@@ -8779,7 +8785,7 @@ export namespace Protocol {
             realm: string;
         }
 
-        export enum AuthChallengeResponseResponse {
+        export const enum AuthChallengeResponseResponse {
             Default = 'Default',
             CancelAuth = 'CancelAuth',
             ProvideCredentials = 'ProvideCredentials',
@@ -8792,9 +8798,9 @@ export namespace Protocol {
             /**
              * The decision on what to do in response to the authorization challenge.  Default means
              * deferring to the default behavior of the net stack, which will likely either the Cancel
-             * authentication or display a popup dialog box.
+             * authentication or display a popup dialog box. (AuthChallengeResponseResponse enum)
              */
-            response: AuthChallengeResponseResponse;
+            response: ('Default' | 'CancelAuth' | 'ProvideCredentials');
             /**
              * The username to provide, possibly empty. Should only be set if response is
              * ProvideCredentials.
@@ -10540,16 +10546,16 @@ export namespace Protocol {
             identifier: ScriptIdentifier;
         }
 
-        export enum CaptureScreenshotRequestFormat {
+        export const enum CaptureScreenshotRequestFormat {
             Jpeg = 'jpeg',
             Png = 'png',
         }
 
         export interface CaptureScreenshotRequest {
             /**
-             * Image compression format (defaults to png).
+             * Image compression format (defaults to png). (CaptureScreenshotRequestFormat enum)
              */
-            format?: CaptureScreenshotRequestFormat;
+            format?: ('jpeg' | 'png');
             /**
              * Compression quality from range [0..100] (jpeg only).
              */
@@ -10571,15 +10577,15 @@ export namespace Protocol {
             data: string;
         }
 
-        export enum CaptureSnapshotRequestFormat {
+        export const enum CaptureSnapshotRequestFormat {
             MHTML = 'mhtml',
         }
 
         export interface CaptureSnapshotRequest {
             /**
-             * Format (defaults to mhtml).
+             * Format (defaults to mhtml). (CaptureSnapshotRequestFormat enum)
              */
-            format?: CaptureSnapshotRequestFormat;
+            format?: ('mhtml');
         }
 
         export interface CaptureSnapshotResponse {
@@ -10773,7 +10779,7 @@ export namespace Protocol {
             entryId: integer;
         }
 
-        export enum PrintToPDFRequestTransferMode {
+        export const enum PrintToPDFRequestTransferMode {
             ReturnAsBase64 = 'ReturnAsBase64',
             ReturnAsStream = 'ReturnAsStream',
         }
@@ -10851,9 +10857,9 @@ export namespace Protocol {
              */
             preferCSSPageSize?: boolean;
             /**
-             * return as stream
+             * return as stream (PrintToPDFRequestTransferMode enum)
              */
-            transferMode?: PrintToPDFRequestTransferMode;
+            transferMode?: ('ReturnAsBase64' | 'ReturnAsStream');
         }
 
         export interface PrintToPDFResponse {
@@ -11030,7 +11036,7 @@ export namespace Protocol {
             html: string;
         }
 
-        export enum SetDownloadBehaviorRequestBehavior {
+        export const enum SetDownloadBehaviorRequestBehavior {
             Deny = 'deny',
             Allow = 'allow',
             Default = 'default',
@@ -11039,9 +11045,9 @@ export namespace Protocol {
         export interface SetDownloadBehaviorRequest {
             /**
              * Whether to allow all or deny all download requests, or use default Chrome behavior if
-             * available (otherwise deny).
+             * available (otherwise deny). (SetDownloadBehaviorRequestBehavior enum)
              */
-            behavior: SetDownloadBehaviorRequestBehavior;
+            behavior: ('deny' | 'allow' | 'default');
             /**
              * The default path to save downloaded files to. This is requred if behavior is set to 'allow'
              */
@@ -11070,7 +11076,7 @@ export namespace Protocol {
             enabled: boolean;
         }
 
-        export enum SetTouchEmulationEnabledRequestConfiguration {
+        export const enum SetTouchEmulationEnabledRequestConfiguration {
             Mobile = 'mobile',
             Desktop = 'desktop',
         }
@@ -11081,21 +11087,21 @@ export namespace Protocol {
              */
             enabled: boolean;
             /**
-             * Touch/gesture events configuration. Default: current platform.
+             * Touch/gesture events configuration. Default: current platform. (SetTouchEmulationEnabledRequestConfiguration enum)
              */
-            configuration?: SetTouchEmulationEnabledRequestConfiguration;
+            configuration?: ('mobile' | 'desktop');
         }
 
-        export enum StartScreencastRequestFormat {
+        export const enum StartScreencastRequestFormat {
             Jpeg = 'jpeg',
             Png = 'png',
         }
 
         export interface StartScreencastRequest {
             /**
-             * Image compression format.
+             * Image compression format. (StartScreencastRequestFormat enum)
              */
-            format?: StartScreencastRequestFormat;
+            format?: ('jpeg' | 'png');
             /**
              * Compression quality from range [0..100].
              */
@@ -11114,16 +11120,16 @@ export namespace Protocol {
             everyNthFrame?: integer;
         }
 
-        export enum SetWebLifecycleStateRequestState {
+        export const enum SetWebLifecycleStateRequestState {
             Frozen = 'frozen',
             Active = 'active',
         }
 
         export interface SetWebLifecycleStateRequest {
             /**
-             * Target lifecycle state
+             * Target lifecycle state (SetWebLifecycleStateRequestState enum)
              */
-            state: SetWebLifecycleStateRequestState;
+            state: ('frozen' | 'active');
         }
 
         export interface SetProduceCompilationCacheRequest {
@@ -11157,7 +11163,7 @@ export namespace Protocol {
             timestamp: Network.MonotonicTime;
         }
 
-        export enum FileChooserOpenedEventMode {
+        export const enum FileChooserOpenedEventMode {
             SelectSingle = 'selectSingle',
             SelectMultiple = 'selectMultiple',
         }
@@ -11175,9 +11181,9 @@ export namespace Protocol {
              */
             backendNodeId: DOM.BackendNodeId;
             /**
-             * Input mode.
+             * Input mode. (FileChooserOpenedEventMode enum)
              */
-            mode: FileChooserOpenedEventMode;
+            mode: ('selectSingle' | 'selectMultiple');
         }
 
         /**
@@ -11316,7 +11322,7 @@ export namespace Protocol {
             suggestedFilename: string;
         }
 
-        export enum DownloadProgressEventState {
+        export const enum DownloadProgressEventState {
             InProgress = 'inProgress',
             Completed = 'completed',
             Canceled = 'canceled',
@@ -11339,9 +11345,9 @@ export namespace Protocol {
              */
             receivedBytes: number;
             /**
-             * Download status.
+             * Download status. (DownloadProgressEventState enum)
              */
-            state: DownloadProgressEventState;
+            state: ('inProgress' | 'completed' | 'canceled');
         }
 
         /**
@@ -11502,28 +11508,28 @@ export namespace Protocol {
             value: number;
         }
 
-        export enum EnableRequestTimeDomain {
+        export const enum EnableRequestTimeDomain {
             TimeTicks = 'timeTicks',
             ThreadTicks = 'threadTicks',
         }
 
         export interface EnableRequest {
             /**
-             * Time domain to use for collecting and reporting duration metrics.
+             * Time domain to use for collecting and reporting duration metrics. (EnableRequestTimeDomain enum)
              */
-            timeDomain?: EnableRequestTimeDomain;
+            timeDomain?: ('timeTicks' | 'threadTicks');
         }
 
-        export enum SetTimeDomainRequestTimeDomain {
+        export const enum SetTimeDomainRequestTimeDomain {
             TimeTicks = 'timeTicks',
             ThreadTicks = 'threadTicks',
         }
 
         export interface SetTimeDomainRequest {
             /**
-             * Time domain
+             * Time domain (SetTimeDomainRequestTimeDomain enum)
              */
-            timeDomain: SetTimeDomainRequestTimeDomain;
+            timeDomain: ('timeTicks' | 'threadTicks');
         }
 
         export interface GetMetricsResponse {
@@ -12668,7 +12674,7 @@ export namespace Protocol {
             [key: string]: string;
         }
 
-        export enum TraceConfigRecordMode {
+        export const enum TraceConfigRecordMode {
             RecordUntilFull = 'recordUntilFull',
             RecordContinuously = 'recordContinuously',
             RecordAsMuchAsPossible = 'recordAsMuchAsPossible',
@@ -12677,9 +12683,9 @@ export namespace Protocol {
 
         export interface TraceConfig {
             /**
-             * Controls how the trace buffer stores data.
+             * Controls how the trace buffer stores data. (TraceConfigRecordMode enum)
              */
-            recordMode?: TraceConfigRecordMode;
+            recordMode?: ('recordUntilFull' | 'recordContinuously' | 'recordAsMuchAsPossible' | 'echoToConsole');
             /**
              * Turns on JavaScript stack sampling.
              */
@@ -12753,7 +12759,7 @@ export namespace Protocol {
             success: boolean;
         }
 
-        export enum StartRequestTransferMode {
+        export const enum StartRequestTransferMode {
             ReportEvents = 'ReportEvents',
             ReturnAsStream = 'ReturnAsStream',
         }
@@ -12773,9 +12779,9 @@ export namespace Protocol {
             bufferUsageReportingInterval?: number;
             /**
              * Whether to report trace events as series of dataCollected events or to save trace to a
-             * stream (defaults to `ReportEvents`).
+             * stream (defaults to `ReportEvents`). (StartRequestTransferMode enum)
              */
-            transferMode?: StartRequestTransferMode;
+            transferMode?: ('ReportEvents' | 'ReturnAsStream');
             /**
              * Trace data format to use. This only applies when using `ReturnAsStream`
              * transfer mode (defaults to `json`).
@@ -12880,7 +12886,7 @@ export namespace Protocol {
             value: string;
         }
 
-        export enum AuthChallengeSource {
+        export const enum AuthChallengeSource {
             Server = 'Server',
             Proxy = 'Proxy',
         }
@@ -12890,9 +12896,9 @@ export namespace Protocol {
          */
         export interface AuthChallenge {
             /**
-             * Source of the authentication challenge.
+             * Source of the authentication challenge. (AuthChallengeSource enum)
              */
-            source?: AuthChallengeSource;
+            source?: ('Server' | 'Proxy');
             /**
              * Origin of the challenger.
              */
@@ -12907,7 +12913,7 @@ export namespace Protocol {
             realm: string;
         }
 
-        export enum AuthChallengeResponseResponse {
+        export const enum AuthChallengeResponseResponse {
             Default = 'Default',
             CancelAuth = 'CancelAuth',
             ProvideCredentials = 'ProvideCredentials',
@@ -12920,9 +12926,9 @@ export namespace Protocol {
             /**
              * The decision on what to do in response to the authorization challenge.  Default means
              * deferring to the default behavior of the net stack, which will likely either the Cancel
-             * authentication or display a popup dialog box.
+             * authentication or display a popup dialog box. (AuthChallengeResponseResponse enum)
              */
-            response: AuthChallengeResponseResponse;
+            response: ('Default' | 'CancelAuth' | 'ProvideCredentials');
             /**
              * The username to provide, possibly empty. Should only be set if response is
              * ProvideCredentials.
@@ -13492,7 +13498,7 @@ export namespace Protocol {
 
         export type Timestamp = number;
 
-        export enum PlayerMessageLevel {
+        export const enum PlayerMessageLevel {
             Error = 'error',
             Warning = 'warning',
             Info = 'info',
@@ -13513,9 +13519,9 @@ export namespace Protocol {
              * representation of a media::PipelineStatus object. Soon however we're
              * going to be moving away from using PipelineStatus for errors and
              * introducing a new error type which should hopefully let us integrate
-             * the error log level into the PlayerError type.
+             * the error log level into the PlayerError type. (PlayerMessageLevel enum)
              */
-            level: PlayerMessageLevel;
+            level: ('error' | 'warning' | 'info' | 'debug');
             message: string;
         }
 
@@ -13535,7 +13541,7 @@ export namespace Protocol {
             value: string;
         }
 
-        export enum PlayerErrorType {
+        export const enum PlayerErrorType {
             Pipeline_error = 'pipeline_error',
             Media_error = 'media_error',
         }
@@ -13544,7 +13550,10 @@ export namespace Protocol {
          * Corresponds to kMediaError
          */
         export interface PlayerError {
-            type: PlayerErrorType;
+            /**
+             *  (PlayerErrorType enum)
+             */
+            type: ('pipeline_error' | 'media_error');
             /**
              * When this switches to using media::Status instead of PipelineStatus
              * we can remove "errorCode" and replace it with the fields from

--- a/types/protocol.d.ts
+++ b/types/protocol.d.ts
@@ -11,6 +11,28 @@ export namespace Protocol {
      */
     export namespace Console {
 
+        export enum ConsoleMessageSource {
+            XML = 'xml',
+            Javascript = 'javascript',
+            Network = 'network',
+            ConsoleAPI = 'console-api',
+            Storage = 'storage',
+            Appcache = 'appcache',
+            Rendering = 'rendering',
+            Security = 'security',
+            Other = 'other',
+            Deprecation = 'deprecation',
+            Worker = 'worker',
+        }
+
+        export enum ConsoleMessageLevel {
+            Log = 'log',
+            Warning = 'warning',
+            Error = 'error',
+            Debug = 'debug',
+            Info = 'info',
+        }
+
         /**
          * Console message.
          */
@@ -18,11 +40,11 @@ export namespace Protocol {
             /**
              * Message source.
              */
-            source: ('xml' | 'javascript' | 'network' | 'console-api' | 'storage' | 'appcache' | 'rendering' | 'security' | 'other' | 'deprecation' | 'worker');
+            source: ConsoleMessageSource;
             /**
              * Message severity.
              */
-            level: ('log' | 'warning' | 'error' | 'debug' | 'info');
+            level: ConsoleMessageLevel;
             /**
              * Message text.
              */
@@ -132,6 +154,19 @@ export namespace Protocol {
             returnValue?: Runtime.RemoteObject;
         }
 
+        export enum ScopeType {
+            Global = 'global',
+            Local = 'local',
+            With = 'with',
+            Closure = 'closure',
+            Catch = 'catch',
+            Block = 'block',
+            Script = 'script',
+            Eval = 'eval',
+            Module = 'module',
+            WasmExpressionStack = 'wasm-expression-stack',
+        }
+
         /**
          * Scope description.
          */
@@ -139,7 +174,7 @@ export namespace Protocol {
             /**
              * Scope type.
              */
-            type: ('global' | 'local' | 'with' | 'closure' | 'catch' | 'block' | 'script' | 'eval' | 'module' | 'wasm-expression-stack');
+            type: ScopeType;
             /**
              * Object representing the scope. For `global` and `with` scopes it represents the actual
              * object; for the rest of the scopes, it is artificial transient object enumerating scope
@@ -171,6 +206,12 @@ export namespace Protocol {
             lineContent: string;
         }
 
+        export enum BreakLocationType {
+            DebuggerStatement = 'debuggerStatement',
+            Call = 'call',
+            Return = 'return',
+        }
+
         export interface BreakLocation {
             /**
              * Script identifier as reported in the `Debugger.scriptParsed`.
@@ -184,13 +225,20 @@ export namespace Protocol {
              * Column number in the script (0-based).
              */
             columnNumber?: integer;
-            type?: ('debuggerStatement' | 'call' | 'return');
+            type?: BreakLocationType;
         }
 
         /**
          * Enum of possible script languages.
          */
         export type ScriptLanguage = ('JavaScript' | 'WebAssembly');
+
+        export enum DebugSymbolsType {
+            None = 'None',
+            SourceMap = 'SourceMap',
+            EmbeddedDWARF = 'EmbeddedDWARF',
+            ExternalDWARF = 'ExternalDWARF',
+        }
 
         /**
          * Debug symbols available for a wasm script.
@@ -199,11 +247,16 @@ export namespace Protocol {
             /**
              * Type of the debug symbols.
              */
-            type: ('None' | 'SourceMap' | 'EmbeddedDWARF' | 'ExternalDWARF');
+            type: DebugSymbolsType;
             /**
              * URL of the external symbol source.
              */
             externalURL?: string;
+        }
+
+        export enum ContinueToLocationRequestTargetCallFrames {
+            Any = 'any',
+            Current = 'current',
         }
 
         export interface ContinueToLocationRequest {
@@ -211,7 +264,7 @@ export namespace Protocol {
              * Location to continue to.
              */
             location: Location;
-            targetCallFrames?: ('any' | 'current');
+            targetCallFrames?: ContinueToLocationRequestTargetCallFrames;
         }
 
         export interface EnableRequest {
@@ -487,11 +540,16 @@ export namespace Protocol {
             actualLocation: Location;
         }
 
+        export enum SetInstrumentationBreakpointRequestInstrumentation {
+            BeforeScriptExecution = 'beforeScriptExecution',
+            BeforeScriptWithSourceMapExecution = 'beforeScriptWithSourceMapExecution',
+        }
+
         export interface SetInstrumentationBreakpointRequest {
             /**
              * Instrumentation name.
              */
-            instrumentation: ('beforeScriptExecution' | 'beforeScriptWithSourceMapExecution');
+            instrumentation: SetInstrumentationBreakpointRequestInstrumentation;
         }
 
         export interface SetInstrumentationBreakpointResponse {
@@ -567,11 +625,17 @@ export namespace Protocol {
             active: boolean;
         }
 
+        export enum SetPauseOnExceptionsRequestState {
+            None = 'none',
+            Uncaught = 'uncaught',
+            All = 'all',
+        }
+
         export interface SetPauseOnExceptionsRequest {
             /**
              * Pause on exceptions mode.
              */
-            state: ('none' | 'uncaught' | 'all');
+            state: SetPauseOnExceptionsRequestState;
         }
 
         export interface SetReturnValueRequest {
@@ -669,6 +733,20 @@ export namespace Protocol {
             location: Location;
         }
 
+        export enum PausedEventReason {
+            Ambiguous = 'ambiguous',
+            Assert = 'assert',
+            DebugCommand = 'debugCommand',
+            DOM = 'DOM',
+            EventListener = 'EventListener',
+            Exception = 'exception',
+            Instrumentation = 'instrumentation',
+            OOM = 'OOM',
+            Other = 'other',
+            PromiseRejection = 'promiseRejection',
+            XHR = 'XHR',
+        }
+
         /**
          * Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria.
          */
@@ -680,7 +758,7 @@ export namespace Protocol {
             /**
              * Pause reason.
              */
-            reason: ('ambiguous' | 'assert' | 'debugCommand' | 'DOM' | 'EventListener' | 'exception' | 'instrumentation' | 'OOM' | 'other' | 'promiseRejection' | 'XHR');
+            reason: PausedEventReason;
             /**
              * Object containing break-specific auxiliary properties.
              */
@@ -1351,6 +1429,44 @@ export namespace Protocol {
          */
         export type UnserializableValue = string;
 
+        export enum RemoteObjectType {
+            Object = 'object',
+            Function = 'function',
+            Undefined = 'undefined',
+            String = 'string',
+            Number = 'number',
+            Boolean = 'boolean',
+            Symbol = 'symbol',
+            Bigint = 'bigint',
+            Wasm = 'wasm',
+        }
+
+        export enum RemoteObjectSubtype {
+            Array = 'array',
+            Null = 'null',
+            Node = 'node',
+            Regexp = 'regexp',
+            Date = 'date',
+            Map = 'map',
+            Set = 'set',
+            Weakmap = 'weakmap',
+            Weakset = 'weakset',
+            Iterator = 'iterator',
+            Generator = 'generator',
+            Error = 'error',
+            Proxy = 'proxy',
+            Promise = 'promise',
+            Typedarray = 'typedarray',
+            Arraybuffer = 'arraybuffer',
+            Dataview = 'dataview',
+            I32 = 'i32',
+            I64 = 'i64',
+            F32 = 'f32',
+            F64 = 'f64',
+            V128 = 'v128',
+            Anyref = 'anyref',
+        }
+
         /**
          * Mirror object referencing original JavaScript object.
          */
@@ -1358,11 +1474,11 @@ export namespace Protocol {
             /**
              * Object type.
              */
-            type: ('object' | 'function' | 'undefined' | 'string' | 'number' | 'boolean' | 'symbol' | 'bigint' | 'wasm');
+            type: RemoteObjectType;
             /**
              * Object subtype hint. Specified for `object` or `wasm` type values only.
              */
-            subtype?: ('array' | 'null' | 'node' | 'regexp' | 'date' | 'map' | 'set' | 'weakmap' | 'weakset' | 'iterator' | 'generator' | 'error' | 'proxy' | 'promise' | 'typedarray' | 'arraybuffer' | 'dataview' | 'i32' | 'i64' | 'f32' | 'f64' | 'v128' | 'anyref');
+            subtype?: RemoteObjectSubtype;
             /**
              * Object class (constructor) name. Specified for `object` type values only.
              */
@@ -1405,6 +1521,32 @@ export namespace Protocol {
             bodyGetterId?: RemoteObjectId;
         }
 
+        export enum ObjectPreviewType {
+            Object = 'object',
+            Function = 'function',
+            Undefined = 'undefined',
+            String = 'string',
+            Number = 'number',
+            Boolean = 'boolean',
+            Symbol = 'symbol',
+            Bigint = 'bigint',
+        }
+
+        export enum ObjectPreviewSubtype {
+            Array = 'array',
+            Null = 'null',
+            Node = 'node',
+            Regexp = 'regexp',
+            Date = 'date',
+            Map = 'map',
+            Set = 'set',
+            Weakmap = 'weakmap',
+            Weakset = 'weakset',
+            Iterator = 'iterator',
+            Generator = 'generator',
+            Error = 'error',
+        }
+
         /**
          * Object containing abbreviated remote object value.
          */
@@ -1412,11 +1554,11 @@ export namespace Protocol {
             /**
              * Object type.
              */
-            type: ('object' | 'function' | 'undefined' | 'string' | 'number' | 'boolean' | 'symbol' | 'bigint');
+            type: ObjectPreviewType;
             /**
              * Object subtype hint. Specified for `object` type values only.
              */
-            subtype?: ('array' | 'null' | 'node' | 'regexp' | 'date' | 'map' | 'set' | 'weakmap' | 'weakset' | 'iterator' | 'generator' | 'error');
+            subtype?: ObjectPreviewSubtype;
             /**
              * String representation of the object.
              */
@@ -1435,6 +1577,33 @@ export namespace Protocol {
             entries?: EntryPreview[];
         }
 
+        export enum PropertyPreviewType {
+            Object = 'object',
+            Function = 'function',
+            Undefined = 'undefined',
+            String = 'string',
+            Number = 'number',
+            Boolean = 'boolean',
+            Symbol = 'symbol',
+            Accessor = 'accessor',
+            Bigint = 'bigint',
+        }
+
+        export enum PropertyPreviewSubtype {
+            Array = 'array',
+            Null = 'null',
+            Node = 'node',
+            Regexp = 'regexp',
+            Date = 'date',
+            Map = 'map',
+            Set = 'set',
+            Weakmap = 'weakmap',
+            Weakset = 'weakset',
+            Iterator = 'iterator',
+            Generator = 'generator',
+            Error = 'error',
+        }
+
         export interface PropertyPreview {
             /**
              * Property name.
@@ -1443,7 +1612,7 @@ export namespace Protocol {
             /**
              * Object type. Accessor means that the property itself is an accessor property.
              */
-            type: ('object' | 'function' | 'undefined' | 'string' | 'number' | 'boolean' | 'symbol' | 'accessor' | 'bigint');
+            type: PropertyPreviewType;
             /**
              * User-friendly property value string.
              */
@@ -1455,7 +1624,7 @@ export namespace Protocol {
             /**
              * Object subtype hint. Specified for `object` type values only.
              */
-            subtype?: ('array' | 'null' | 'node' | 'regexp' | 'date' | 'map' | 'set' | 'weakmap' | 'weakset' | 'iterator' | 'generator' | 'error');
+            subtype?: PropertyPreviewSubtype;
         }
 
         export interface EntryPreview {
@@ -2096,6 +2265,27 @@ export namespace Protocol {
             executionContextId: ExecutionContextId;
         }
 
+        export enum ConsoleAPICalledEventType {
+            Log = 'log',
+            Debug = 'debug',
+            Info = 'info',
+            Error = 'error',
+            Warning = 'warning',
+            Dir = 'dir',
+            DirXML = 'dirxml',
+            Table = 'table',
+            Trace = 'trace',
+            Clear = 'clear',
+            StartGroup = 'startGroup',
+            StartGroupCollapsed = 'startGroupCollapsed',
+            EndGroup = 'endGroup',
+            Assert = 'assert',
+            Profile = 'profile',
+            ProfileEnd = 'profileEnd',
+            Count = 'count',
+            TimeEnd = 'timeEnd',
+        }
+
         /**
          * Issued when console API was called.
          */
@@ -2103,7 +2293,7 @@ export namespace Protocol {
             /**
              * Type of the call.
              */
-            type: ('log' | 'debug' | 'info' | 'error' | 'warning' | 'dir' | 'dirxml' | 'table' | 'trace' | 'clear' | 'startGroup' | 'startGroupCollapsed' | 'endGroup' | 'assert' | 'profile' | 'profileEnd' | 'count' | 'timeEnd');
+            type: ConsoleAPICalledEventType;
             /**
              * Call arguments.
              */
@@ -2414,6 +2604,12 @@ export namespace Protocol {
 
     export namespace Animation {
 
+        export enum AnimationType {
+            CSSTransition = 'CSSTransition',
+            CSSAnimation = 'CSSAnimation',
+            WebAnimation = 'WebAnimation',
+        }
+
         /**
          * Animation instance.
          */
@@ -2449,7 +2645,7 @@ export namespace Protocol {
             /**
              * Animation type of `Animation`.
              */
-            type: ('CSSTransition' | 'CSSAnimation' | 'WebAnimation');
+            type: AnimationType;
             /**
              * `Animation`'s source animation node.
              */
@@ -2910,6 +3106,12 @@ export namespace Protocol {
             details: InspectorIssueDetails;
         }
 
+        export enum GetEncodedResponseRequestEncoding {
+            Webp = 'webp',
+            Jpeg = 'jpeg',
+            Png = 'png',
+        }
+
         export interface GetEncodedResponseRequest {
             /**
              * Identifier of the network request to get content for.
@@ -2918,7 +3120,7 @@ export namespace Protocol {
             /**
              * The encoding to use.
              */
-            encoding: ('webp' | 'jpeg' | 'png');
+            encoding: GetEncodedResponseRequestEncoding;
             /**
              * The quality of the encoding (0-1). (defaults to 1)
              */
@@ -3185,13 +3387,20 @@ export namespace Protocol {
             browserContextId?: BrowserContextID;
         }
 
+        export enum SetDownloadBehaviorRequestBehavior {
+            Deny = 'deny',
+            Allow = 'allow',
+            AllowAndName = 'allowAndName',
+            Default = 'default',
+        }
+
         export interface SetDownloadBehaviorRequest {
             /**
              * Whether to allow all or deny all download requests, or use default Chrome behavior if
              * available (otherwise deny). |allowAndName| allows download and names files according to
              * their dowmload guids.
              */
-            behavior: ('deny' | 'allow' | 'allowAndName' | 'default');
+            behavior: SetDownloadBehaviorRequestBehavior;
             /**
              * BrowserContext to set download behavior. When omitted, default browser context is used.
              */
@@ -3646,6 +3855,13 @@ export namespace Protocol {
             range?: SourceRange;
         }
 
+        export enum CSSMediaSource {
+            MediaRule = 'mediaRule',
+            ImportRule = 'importRule',
+            LinkedSheet = 'linkedSheet',
+            InlineSheet = 'inlineSheet',
+        }
+
         /**
          * CSS media rule descriptor.
          */
@@ -3660,7 +3876,7 @@ export namespace Protocol {
              * stylesheet's LINK tag, "inlineSheet" if specified by a "media" attribute in an inline
              * stylesheet's STYLE tag.
              */
-            source: ('mediaRule' | 'importRule' | 'linkedSheet' | 'inlineSheet');
+            source: CSSMediaSource;
             /**
              * URL of the document containing the media query description.
              */
@@ -6241,6 +6457,13 @@ export namespace Protocol {
      */
     export namespace Emulation {
 
+        export enum ScreenOrientationType {
+            PortraitPrimary = 'portraitPrimary',
+            PortraitSecondary = 'portraitSecondary',
+            LandscapePrimary = 'landscapePrimary',
+            LandscapeSecondary = 'landscapeSecondary',
+        }
+
         /**
          * Screen orientation.
          */
@@ -6248,7 +6471,7 @@ export namespace Protocol {
             /**
              * Orientation type.
              */
-            type: ('portraitPrimary' | 'portraitSecondary' | 'landscapePrimary' | 'landscapeSecondary');
+            type: ScreenOrientationType;
             /**
              * Orientation angle.
              */
@@ -6385,6 +6608,11 @@ export namespace Protocol {
             disabled: boolean;
         }
 
+        export enum SetEmitTouchEventsForMouseRequestConfiguration {
+            Mobile = 'mobile',
+            Desktop = 'desktop',
+        }
+
         export interface SetEmitTouchEventsForMouseRequest {
             /**
              * Whether touch emulation based on mouse input should be enabled.
@@ -6393,7 +6621,7 @@ export namespace Protocol {
             /**
              * Touch/gesture events configuration. Default: current platform.
              */
-            configuration?: ('mobile' | 'desktop');
+            configuration?: SetEmitTouchEventsForMouseRequestConfiguration;
         }
 
         export interface SetEmulatedMediaRequest {
@@ -6407,11 +6635,20 @@ export namespace Protocol {
             features?: MediaFeature[];
         }
 
+        export enum SetEmulatedVisionDeficiencyRequestType {
+            None = 'none',
+            Achromatopsia = 'achromatopsia',
+            BlurredVision = 'blurredVision',
+            Deuteranopia = 'deuteranopia',
+            Protanopia = 'protanopia',
+            Tritanopia = 'tritanopia',
+        }
+
         export interface SetEmulatedVisionDeficiencyRequest {
             /**
              * Vision deficiency to emulate.
              */
-            type: ('none' | 'achromatopsia' | 'blurredVision' | 'deuteranopia' | 'protanopia' | 'tritanopia');
+            type: SetEmulatedVisionDeficiencyRequestType;
         }
 
         export interface SetGeolocationOverrideRequest {
@@ -6543,6 +6780,11 @@ export namespace Protocol {
      */
     export namespace HeadlessExperimental {
 
+        export enum ScreenshotParamsFormat {
+            Jpeg = 'jpeg',
+            Png = 'png',
+        }
+
         /**
          * Encoding options for a screenshot.
          */
@@ -6550,7 +6792,7 @@ export namespace Protocol {
             /**
              * Image compression format (defaults to png).
              */
-            format?: ('jpeg' | 'png');
+            format?: ScreenshotParamsFormat;
             /**
              * Compression quality from range [0..100] (jpeg only).
              */
@@ -6736,6 +6978,13 @@ export namespace Protocol {
             multiEntry: boolean;
         }
 
+        export enum KeyType {
+            Number = 'number',
+            String = 'string',
+            Date = 'date',
+            Array = 'array',
+        }
+
         /**
          * Key.
          */
@@ -6743,7 +6992,7 @@ export namespace Protocol {
             /**
              * Key type.
              */
-            type: ('number' | 'string' | 'date' | 'array');
+            type: KeyType;
             /**
              * Number value.
              */
@@ -6802,6 +7051,12 @@ export namespace Protocol {
             value: Runtime.RemoteObject;
         }
 
+        export enum KeyPathType {
+            Null = 'null',
+            String = 'string',
+            Array = 'array',
+        }
+
         /**
          * Key path.
          */
@@ -6809,7 +7064,7 @@ export namespace Protocol {
             /**
              * Key path type.
              */
-            type: ('null' | 'string' | 'array');
+            type: KeyPathType;
             /**
              * String value.
              */
@@ -7002,11 +7257,18 @@ export namespace Protocol {
          */
         export type TimeSinceEpoch = number;
 
+        export enum DispatchKeyEventRequestType {
+            KeyDown = 'keyDown',
+            KeyUp = 'keyUp',
+            RawKeyDown = 'rawKeyDown',
+            Char = 'char',
+        }
+
         export interface DispatchKeyEventRequest {
             /**
              * Type of the key event.
              */
-            type: ('keyDown' | 'keyUp' | 'rawKeyDown' | 'char');
+            type: DispatchKeyEventRequestType;
             /**
              * Bit field representing pressed modifier keys. Alt=1, Ctrl=2, Meta/Command=4, Shift=8
              * (default: 0).
@@ -7073,11 +7335,23 @@ export namespace Protocol {
             text: string;
         }
 
+        export enum DispatchMouseEventRequestType {
+            MousePressed = 'mousePressed',
+            MouseReleased = 'mouseReleased',
+            MouseMoved = 'mouseMoved',
+            MouseWheel = 'mouseWheel',
+        }
+
+        export enum DispatchMouseEventRequestPointerType {
+            Mouse = 'mouse',
+            Pen = 'pen',
+        }
+
         export interface DispatchMouseEventRequest {
             /**
              * Type of the mouse event.
              */
-            type: ('mousePressed' | 'mouseReleased' | 'mouseMoved' | 'mouseWheel');
+            type: DispatchMouseEventRequestType;
             /**
              * X coordinate of the event relative to the main frame's viewport in CSS pixels.
              */
@@ -7120,7 +7394,14 @@ export namespace Protocol {
             /**
              * Pointer type (default: "mouse").
              */
-            pointerType?: ('mouse' | 'pen');
+            pointerType?: DispatchMouseEventRequestPointerType;
+        }
+
+        export enum DispatchTouchEventRequestType {
+            TouchStart = 'touchStart',
+            TouchEnd = 'touchEnd',
+            TouchMove = 'touchMove',
+            TouchCancel = 'touchCancel',
         }
 
         export interface DispatchTouchEventRequest {
@@ -7128,7 +7409,7 @@ export namespace Protocol {
              * Type of the touch event. TouchEnd and TouchCancel must not contain any touch points, while
              * TouchStart and TouchMove must contains at least one.
              */
-            type: ('touchStart' | 'touchEnd' | 'touchMove' | 'touchCancel');
+            type: DispatchTouchEventRequestType;
             /**
              * Active touch points on the touch device. One event per any changed point (compared to
              * previous touch event in a sequence) is generated, emulating pressing/moving/releasing points
@@ -7146,11 +7427,18 @@ export namespace Protocol {
             timestamp?: TimeSinceEpoch;
         }
 
+        export enum EmulateTouchFromMouseEventRequestType {
+            MousePressed = 'mousePressed',
+            MouseReleased = 'mouseReleased',
+            MouseMoved = 'mouseMoved',
+            MouseWheel = 'mouseWheel',
+        }
+
         export interface EmulateTouchFromMouseEventRequest {
             /**
              * Type of the mouse event.
              */
-            type: ('mousePressed' | 'mouseReleased' | 'mouseMoved' | 'mouseWheel');
+            type: EmulateTouchFromMouseEventRequestType;
             /**
              * X coordinate of the mouse pointer in DIP.
              */
@@ -7321,6 +7609,12 @@ export namespace Protocol {
          */
         export type SnapshotId = string;
 
+        export enum ScrollRectType {
+            RepaintsOnScroll = 'RepaintsOnScroll',
+            TouchEventHandler = 'TouchEventHandler',
+            WheelEventHandler = 'WheelEventHandler',
+        }
+
         /**
          * Rectangle where scrolling happens on the main thread.
          */
@@ -7332,7 +7626,7 @@ export namespace Protocol {
             /**
              * Reason for rectangle to force scrolling on the main thread
              */
-            type: ('RepaintsOnScroll' | 'TouchEventHandler' | 'WheelEventHandler');
+            type: ScrollRectType;
         }
 
         /**
@@ -7594,6 +7888,29 @@ export namespace Protocol {
      */
     export namespace Log {
 
+        export enum LogEntrySource {
+            XML = 'xml',
+            Javascript = 'javascript',
+            Network = 'network',
+            Storage = 'storage',
+            Appcache = 'appcache',
+            Rendering = 'rendering',
+            Security = 'security',
+            Deprecation = 'deprecation',
+            Worker = 'worker',
+            Violation = 'violation',
+            Intervention = 'intervention',
+            Recommendation = 'recommendation',
+            Other = 'other',
+        }
+
+        export enum LogEntryLevel {
+            Verbose = 'verbose',
+            Info = 'info',
+            Warning = 'warning',
+            Error = 'error',
+        }
+
         /**
          * Log entry.
          */
@@ -7601,11 +7918,11 @@ export namespace Protocol {
             /**
              * Log entry source.
              */
-            source: ('xml' | 'javascript' | 'network' | 'storage' | 'appcache' | 'rendering' | 'security' | 'deprecation' | 'worker' | 'violation' | 'intervention' | 'recommendation' | 'other');
+            source: LogEntrySource;
             /**
              * Log entry severity.
              */
-            level: ('verbose' | 'info' | 'warning' | 'error');
+            level: LogEntryLevel;
             /**
              * Logged text.
              */
@@ -7640,6 +7957,16 @@ export namespace Protocol {
             args?: Runtime.RemoteObject[];
         }
 
+        export enum ViolationSettingName {
+            LongTask = 'longTask',
+            LongLayout = 'longLayout',
+            BlockedEvent = 'blockedEvent',
+            BlockedParser = 'blockedParser',
+            DiscouragedAPIUse = 'discouragedAPIUse',
+            Handler = 'handler',
+            RecurringHandler = 'recurringHandler',
+        }
+
         /**
          * Violation configuration setting.
          */
@@ -7647,7 +7974,7 @@ export namespace Protocol {
             /**
              * Violation type.
              */
-            name: ('longTask' | 'longLayout' | 'blockedEvent' | 'blockedParser' | 'discouragedAPIUse' | 'handler' | 'recurringHandler');
+            name: ViolationSettingName;
             /**
              * Time threshold to trigger upon.
              */
@@ -7921,6 +8248,17 @@ export namespace Protocol {
          */
         export type ResourcePriority = ('VeryLow' | 'Low' | 'Medium' | 'High' | 'VeryHigh');
 
+        export enum RequestReferrerPolicy {
+            UnsafeUrl = 'unsafe-url',
+            NoReferrerWhenDowngrade = 'no-referrer-when-downgrade',
+            NoReferrer = 'no-referrer',
+            Origin = 'origin',
+            OriginWhenCrossOrigin = 'origin-when-cross-origin',
+            SameOrigin = 'same-origin',
+            StrictOrigin = 'strict-origin',
+            StrictOriginWhenCrossOrigin = 'strict-origin-when-cross-origin',
+        }
+
         /**
          * HTTP request data.
          */
@@ -7960,7 +8298,7 @@ export namespace Protocol {
             /**
              * The referrer policy of the request, as defined in https://www.w3.org/TR/referrer-policy/
              */
-            referrerPolicy: ('unsafe-url' | 'no-referrer-when-downgrade' | 'no-referrer' | 'origin' | 'origin-when-cross-origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin');
+            referrerPolicy: RequestReferrerPolicy;
             /**
              * Whether is loaded via link preload.
              */
@@ -8241,6 +8579,14 @@ export namespace Protocol {
             bodySize: number;
         }
 
+        export enum InitiatorType {
+            Parser = 'parser',
+            Script = 'script',
+            Preload = 'preload',
+            SignedExchange = 'SignedExchange',
+            Other = 'other',
+        }
+
         /**
          * Information about the request initiator.
          */
@@ -8248,7 +8594,7 @@ export namespace Protocol {
             /**
              * Type of this initiator.
              */
-            type: ('parser' | 'script' | 'preload' | 'SignedExchange' | 'other');
+            type: InitiatorType;
             /**
              * Initiator JavaScript stack trace, set for Script only.
              */
@@ -8406,6 +8752,11 @@ export namespace Protocol {
             priority?: CookiePriority;
         }
 
+        export enum AuthChallengeSource {
+            Server = 'Server',
+            Proxy = 'Proxy',
+        }
+
         /**
          * Authorization challenge for HTTP status code 401 or 407.
          */
@@ -8413,7 +8764,7 @@ export namespace Protocol {
             /**
              * Source of the authentication challenge.
              */
-            source?: ('Server' | 'Proxy');
+            source?: AuthChallengeSource;
             /**
              * Origin of the challenger.
              */
@@ -8428,6 +8779,12 @@ export namespace Protocol {
             realm: string;
         }
 
+        export enum AuthChallengeResponseResponse {
+            Default = 'Default',
+            CancelAuth = 'CancelAuth',
+            ProvideCredentials = 'ProvideCredentials',
+        }
+
         /**
          * Response to an AuthChallenge.
          */
@@ -8437,7 +8794,7 @@ export namespace Protocol {
              * deferring to the default behavior of the net stack, which will likely either the Cancel
              * authentication or display a popup dialog box.
              */
-            response: ('Default' | 'CancelAuth' | 'ProvideCredentials');
+            response: AuthChallengeResponseResponse;
             /**
              * The username to provide, possibly empty. Should only be set if response is
              * ProvideCredentials.
@@ -10183,11 +10540,16 @@ export namespace Protocol {
             identifier: ScriptIdentifier;
         }
 
+        export enum CaptureScreenshotRequestFormat {
+            Jpeg = 'jpeg',
+            Png = 'png',
+        }
+
         export interface CaptureScreenshotRequest {
             /**
              * Image compression format (defaults to png).
              */
-            format?: ('jpeg' | 'png');
+            format?: CaptureScreenshotRequestFormat;
             /**
              * Compression quality from range [0..100] (jpeg only).
              */
@@ -10209,11 +10571,15 @@ export namespace Protocol {
             data: string;
         }
 
+        export enum CaptureSnapshotRequestFormat {
+            MHTML = 'mhtml',
+        }
+
         export interface CaptureSnapshotRequest {
             /**
              * Format (defaults to mhtml).
              */
-            format?: ('mhtml');
+            format?: CaptureSnapshotRequestFormat;
         }
 
         export interface CaptureSnapshotResponse {
@@ -10407,6 +10773,11 @@ export namespace Protocol {
             entryId: integer;
         }
 
+        export enum PrintToPDFRequestTransferMode {
+            ReturnAsBase64 = 'ReturnAsBase64',
+            ReturnAsStream = 'ReturnAsStream',
+        }
+
         export interface PrintToPDFRequest {
             /**
              * Paper orientation. Defaults to false.
@@ -10482,7 +10853,7 @@ export namespace Protocol {
             /**
              * return as stream
              */
-            transferMode?: ('ReturnAsBase64' | 'ReturnAsStream');
+            transferMode?: PrintToPDFRequestTransferMode;
         }
 
         export interface PrintToPDFResponse {
@@ -10659,12 +11030,18 @@ export namespace Protocol {
             html: string;
         }
 
+        export enum SetDownloadBehaviorRequestBehavior {
+            Deny = 'deny',
+            Allow = 'allow',
+            Default = 'default',
+        }
+
         export interface SetDownloadBehaviorRequest {
             /**
              * Whether to allow all or deny all download requests, or use default Chrome behavior if
              * available (otherwise deny).
              */
-            behavior: ('deny' | 'allow' | 'default');
+            behavior: SetDownloadBehaviorRequestBehavior;
             /**
              * The default path to save downloaded files to. This is requred if behavior is set to 'allow'
              */
@@ -10693,6 +11070,11 @@ export namespace Protocol {
             enabled: boolean;
         }
 
+        export enum SetTouchEmulationEnabledRequestConfiguration {
+            Mobile = 'mobile',
+            Desktop = 'desktop',
+        }
+
         export interface SetTouchEmulationEnabledRequest {
             /**
              * Whether the touch event emulation should be enabled.
@@ -10701,14 +11083,19 @@ export namespace Protocol {
             /**
              * Touch/gesture events configuration. Default: current platform.
              */
-            configuration?: ('mobile' | 'desktop');
+            configuration?: SetTouchEmulationEnabledRequestConfiguration;
+        }
+
+        export enum StartScreencastRequestFormat {
+            Jpeg = 'jpeg',
+            Png = 'png',
         }
 
         export interface StartScreencastRequest {
             /**
              * Image compression format.
              */
-            format?: ('jpeg' | 'png');
+            format?: StartScreencastRequestFormat;
             /**
              * Compression quality from range [0..100].
              */
@@ -10727,11 +11114,16 @@ export namespace Protocol {
             everyNthFrame?: integer;
         }
 
+        export enum SetWebLifecycleStateRequestState {
+            Frozen = 'frozen',
+            Active = 'active',
+        }
+
         export interface SetWebLifecycleStateRequest {
             /**
              * Target lifecycle state
              */
-            state: ('frozen' | 'active');
+            state: SetWebLifecycleStateRequestState;
         }
 
         export interface SetProduceCompilationCacheRequest {
@@ -10765,6 +11157,11 @@ export namespace Protocol {
             timestamp: Network.MonotonicTime;
         }
 
+        export enum FileChooserOpenedEventMode {
+            SelectSingle = 'selectSingle',
+            SelectMultiple = 'selectMultiple',
+        }
+
         /**
          * Emitted only when `page.interceptFileChooser` is enabled.
          */
@@ -10780,7 +11177,7 @@ export namespace Protocol {
             /**
              * Input mode.
              */
-            mode: ('selectSingle' | 'selectMultiple');
+            mode: FileChooserOpenedEventMode;
         }
 
         /**
@@ -10919,6 +11316,12 @@ export namespace Protocol {
             suggestedFilename: string;
         }
 
+        export enum DownloadProgressEventState {
+            InProgress = 'inProgress',
+            Completed = 'completed',
+            Canceled = 'canceled',
+        }
+
         /**
          * Fired when download makes progress. Last call has |done| == true.
          */
@@ -10938,7 +11341,7 @@ export namespace Protocol {
             /**
              * Download status.
              */
-            state: ('inProgress' | 'completed' | 'canceled');
+            state: DownloadProgressEventState;
         }
 
         /**
@@ -11099,18 +11502,28 @@ export namespace Protocol {
             value: number;
         }
 
+        export enum EnableRequestTimeDomain {
+            TimeTicks = 'timeTicks',
+            ThreadTicks = 'threadTicks',
+        }
+
         export interface EnableRequest {
             /**
              * Time domain to use for collecting and reporting duration metrics.
              */
-            timeDomain?: ('timeTicks' | 'threadTicks');
+            timeDomain?: EnableRequestTimeDomain;
+        }
+
+        export enum SetTimeDomainRequestTimeDomain {
+            TimeTicks = 'timeTicks',
+            ThreadTicks = 'threadTicks',
         }
 
         export interface SetTimeDomainRequest {
             /**
              * Time domain
              */
-            timeDomain: ('timeTicks' | 'threadTicks');
+            timeDomain: SetTimeDomainRequestTimeDomain;
         }
 
         export interface GetMetricsResponse {
@@ -12255,11 +12668,18 @@ export namespace Protocol {
             [key: string]: string;
         }
 
+        export enum TraceConfigRecordMode {
+            RecordUntilFull = 'recordUntilFull',
+            RecordContinuously = 'recordContinuously',
+            RecordAsMuchAsPossible = 'recordAsMuchAsPossible',
+            EchoToConsole = 'echoToConsole',
+        }
+
         export interface TraceConfig {
             /**
              * Controls how the trace buffer stores data.
              */
-            recordMode?: ('recordUntilFull' | 'recordContinuously' | 'recordAsMuchAsPossible' | 'echoToConsole');
+            recordMode?: TraceConfigRecordMode;
             /**
              * Turns on JavaScript stack sampling.
              */
@@ -12333,6 +12753,11 @@ export namespace Protocol {
             success: boolean;
         }
 
+        export enum StartRequestTransferMode {
+            ReportEvents = 'ReportEvents',
+            ReturnAsStream = 'ReturnAsStream',
+        }
+
         export interface StartRequest {
             /**
              * Category/tag filter
@@ -12350,7 +12775,7 @@ export namespace Protocol {
              * Whether to report trace events as series of dataCollected events or to save trace to a
              * stream (defaults to `ReportEvents`).
              */
-            transferMode?: ('ReportEvents' | 'ReturnAsStream');
+            transferMode?: StartRequestTransferMode;
             /**
              * Trace data format to use. This only applies when using `ReturnAsStream`
              * transfer mode (defaults to `json`).
@@ -12455,6 +12880,11 @@ export namespace Protocol {
             value: string;
         }
 
+        export enum AuthChallengeSource {
+            Server = 'Server',
+            Proxy = 'Proxy',
+        }
+
         /**
          * Authorization challenge for HTTP status code 401 or 407.
          */
@@ -12462,7 +12892,7 @@ export namespace Protocol {
             /**
              * Source of the authentication challenge.
              */
-            source?: ('Server' | 'Proxy');
+            source?: AuthChallengeSource;
             /**
              * Origin of the challenger.
              */
@@ -12477,6 +12907,12 @@ export namespace Protocol {
             realm: string;
         }
 
+        export enum AuthChallengeResponseResponse {
+            Default = 'Default',
+            CancelAuth = 'CancelAuth',
+            ProvideCredentials = 'ProvideCredentials',
+        }
+
         /**
          * Response to an AuthChallenge.
          */
@@ -12486,7 +12922,7 @@ export namespace Protocol {
              * deferring to the default behavior of the net stack, which will likely either the Cancel
              * authentication or display a popup dialog box.
              */
-            response: ('Default' | 'CancelAuth' | 'ProvideCredentials');
+            response: AuthChallengeResponseResponse;
             /**
              * The username to provide, possibly empty. Should only be set if response is
              * ProvideCredentials.
@@ -13056,6 +13492,13 @@ export namespace Protocol {
 
         export type Timestamp = number;
 
+        export enum PlayerMessageLevel {
+            Error = 'error',
+            Warning = 'warning',
+            Info = 'info',
+            Debug = 'debug',
+        }
+
         /**
          * Have one type per entry in MediaLogRecord::Type
          * Corresponds to kMessage
@@ -13072,7 +13515,7 @@ export namespace Protocol {
              * introducing a new error type which should hopefully let us integrate
              * the error log level into the PlayerError type.
              */
-            level: ('error' | 'warning' | 'info' | 'debug');
+            level: PlayerMessageLevel;
             message: string;
         }
 
@@ -13092,11 +13535,16 @@ export namespace Protocol {
             value: string;
         }
 
+        export enum PlayerErrorType {
+            Pipeline_error = 'pipeline_error',
+            Media_error = 'media_error',
+        }
+
         /**
          * Corresponds to kMediaError
          */
         export interface PlayerError {
-            type: ('pipeline_error' | 'media_error');
+            type: PlayerErrorType;
             /**
              * When this switches to using media::Status instead of PipelineStatus
              * we can remove "errorCode" and replace it with the fields from


### PR DESCRIPTION
Note: this change is taken directly from this DevTools CL (we should
explore getting DevTools to depend on this module to avoid the
duplication): https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/2113374. I'm happy to take that on.

This PR takes the work Simon did from DevTools into this repo - although it's me committing this is all his work!

This change is motivated by moving Puppeteer to TypeScript and wanting
to control types more strictly rather than declaring arguments as
strings even though really only a subset are supported.

I've copied the commit message from the above here:

Commands, Events and Object types can declare "inline enums" to
restrict the possible values of a 'string' field.

Example field:

```
  referrerPolicy: ('unsafe-url'|'...'|'...')
```

To enable type-checking with TypeScript and stay compatible with
existing code, we now generate explicit enums.
for the enum names is adapted from code_generator_frontend.py
and needs to always match.

Example generated enum for the above code:

```ts
  export enum RequestReferrerPolicy {
    UnsafeUrl = 'unsafe-url',
    NoReferrerWhenDowngrade = 'no-referrer-when-downgrade',
    NoReferrer = 'no-referrer',
    Origin = 'origin',
    OriginWhenCrossOrigin = 'origin-when-cross-origin',
    SameOrigin = 'same-origin',
    StrictOrigin = 'strict-origin',
    StrictOriginWhenCrossOrigin = 'strict-origin-when-cross-origin',
  }
```