### PR TITLE
Explicitly specify folders to be included in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-scripts
-.git

--- a/package.json
+++ b/package.json
@@ -8,5 +8,11 @@
   "bugs": {
     "url": "https://github.com/ChromeDevTools/devtools-protocol/issues"
   },
+  "files": [
+    "externs",
+    "json",
+    "pdl",
+    "types"
+  ],
   "types": "types/protocol.d.ts"
 }


### PR DESCRIPTION
Previously, `.github/*` was included in the package. I’ve confirmed with `npm pack` that this is the only difference introduced by this patch.

Note that I’ve removed `.npmignore` since it’s a denylist (and thus easy to get out of date, which happened here), whereas `package.json#files` is an allowlist.