### PR TITLE
Avoid trailing whitespace in changelog.md

### DIFF
--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -214,7 +214,7 @@ class Formatter {
       text += textChange + (count > 1 ? ` (${count} times). ` : '. ');
     };
 
-    return text;
+    return text.trimEnd();
   }
 
   static getKey(obj) {


### PR DESCRIPTION
We noticed this when rolling the new version of Puppeteer, which depends on `devtools-protocol`, into devtools-frontend. One of our presubmit checks was complaining about the trailing whitespace. We can bypass it, but here's a patch in case you wanna fix it upstream.

Note: I didn't include the `changelog.md` changes in this PR to avoid merge conflicts. Maybe we can just land it and let the cronjob take care of the update?