### PR TITLE
generate protocol proxy api member to remove api event listener

### DIFF
--- a/scripts/protocol-dts-generator.ts
+++ b/scripts/protocol-dts-generator.ts
@@ -236,7 +236,7 @@ const emitEvent = (event: P.Event) => {
     if (!event.parameters) {
         return
     }
-    
+
     emitInlineEnumsForEvents(event);
     emitLine()
     emitDescription(event.description)
@@ -329,6 +329,7 @@ const emitApiEvent = (event: P.Event, domainName: string, modulePrefix: string) 
     emitDescription(event.description)
     const params = event.parameters ? `params: ${prefix}${toEventPayloadName(event.name)}` : ''
     emitLine(`on(event: '${event.name}', listener: (${params}) => void): void;`)
+    emitLine(`off(event: '${event.name}', listener: (${params}) => void): void;`)
     emitLine()
 }
 


### PR DESCRIPTION
Currently, protocol proxy API exports function to add event listeners but not to remove them, this PR extends the generate to add an `off` function with the same signature as the `on` function, which can be used to remove event listeners