### PR TITLE
Add `Promise` version of events

### DIFF
--- a/scripts/protocol-dts-generator.ts
+++ b/scripts/protocol-dts-generator.ts
@@ -324,11 +324,15 @@ const emitApiCommand = (command: P.Command, domainName: string, modulePrefix: st
     emitLine()
 }
 
-const emitApiEvent = (event: P.Event, domainName: string, modulePrefix: string) => {
+const emitApiEvent = (event: P.Event, domainName: string, modulePrefix: string, promiseApi: boolean) => {
     const prefix = `${modulePrefix}.${domainName}.`
     emitDescription(event.description)
     const params = event.parameters ? `params: ${prefix}${toEventPayloadName(event.name)}` : ''
-    emitLine(`on(event: '${event.name}', listener: (${params}) => void): void;`)
+    if (promiseApi) {
+        emitLine(`${event.name}(): Promise<${params ? params.slice(8) : 'void'}>;`)
+    } else {
+        emitLine(`on(event: '${event.name}', listener: (${params}) => void): void;`)
+    }
     emitLine()
 }
 
@@ -337,7 +341,10 @@ const emitDomainApi = (domain: P.Domain, modulePrefix: string) => {
     const domainName = toTitleCase(domain.domain)
     emitOpenBlock(`export interface ${domainName}Api`)
     if (domain.commands) domain.commands.forEach(c => emitApiCommand(c, domainName, modulePrefix))
-    if (domain.events) domain.events.forEach(e => emitApiEvent(e, domainName, modulePrefix))
+    if (domain.events) {
+        domain.events.forEach(e => emitApiEvent(e, domainName, modulePrefix, false))
+        domain.events.forEach(e => emitApiEvent(e, domainName, modulePrefix, true))
+    }
     emitCloseBlock()
 }
 


### PR DESCRIPTION
This pr extends the generator script to add `Promise` versions of events, e.g.:

```ts
domContentEventFired(): Promise<Protocol.Page.DomContentEventFiredEvent>;
```
as a complement for
```ts
on(event: 'domContentEventFired', listener: (params: Protocol.Page.DomContentEventFiredEvent) => void): void;
```

----

The motivation for this pr is to provide typings support for the following syntax:

```ts
const {Page} = client;
await Page.domContentEventFired();
```

Currently, typings support is provided for the following syntax via DefinitelyTyped's `chrome-remote-interface` typings:
```ts
await client['Page.domContentEventFired']();
```
but it is less elegant and the `client` part shouldn't really be necessary. Unfortunately, it doesn't seem possible to provide typings for the former syntax via `protocol-mapping.d.ts` since it is not possible to split something like `'Page.domContentEventFired'` into its component parts with the current version of TypeScript (4.3).

----

In the code, there are two `forEach` loops for `emitApiEvent()` so that all the `on()` overloads are kept together.

Fixes #246.