### PR TITLE
Clarify which package to update

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -14,7 +14,6 @@ jobs:
       - name: Publish
         env:
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}
-        working-directory: scripts
         run: |
           npm config set registry 'https://wombat-dressing-room.appspot.com/'
           npm config set '//wombat-dressing-room.appspot.com/:_authToken' '${NPM_TOKEN}'

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,7 +1,6 @@
 {
-  "version": "0.0.510771",
+  "private": true,
   "license": "SEE LICENSE IN https://chromium.googlesource.com/chromium/src/+/main/LICENSE",
-  "repository": "ChromeDevTools/devtools-protocol",
   "scripts": {
     "build-protocol-dts": "ts-node protocol-dts-generator.ts",
     "type-check": "tsc -p tsconfig.json",

--- a/scripts/update-to-latest.sh
+++ b/scripts/update-to-latest.sh
@@ -67,6 +67,7 @@ if ! git diff --no-ext-diff --quiet --exit-code; then
 	npm run changelog
 
 	# bump npm version
+	cd "$protocol_repo_path"
 	npm version --no-git-tag-version "0.0.$commit_rev"
 
 	# amend previous commit


### PR DESCRIPTION
`scripts/package.json` is an implementation detail of this repository; it doesn’t need a `version` and can be marked as `private`.

The package that gets published to npm is the one controlled by the `package.json` in the repository’s root directory.

Issue: #266