### PR TITLE
Remove DevTools "prompt" permission override option

### DIFF
--- a/types/protocol.d.ts
+++ b/types/protocol.d.ts
@@ -3734,7 +3734,7 @@ export namespace Protocol {
 
         export type PermissionType = ('accessibilityEvents' | 'audioCapture' | 'backgroundSync' | 'backgroundFetch' | 'clipboardReadWrite' | 'clipboardSanitizedWrite' | 'displayCapture' | 'durableStorage' | 'flash' | 'geolocation' | 'midi' | 'midiSysex' | 'nfc' | 'notifications' | 'paymentHandler' | 'periodicBackgroundSync' | 'protectedMediaIdentifier' | 'sensors' | 'videoCapture' | 'videoCapturePanTiltZoom' | 'idleDetection' | 'wakeLockScreen' | 'wakeLockSystem');
 
-        export type PermissionSetting = ('granted' | 'denied' | 'prompt');
+        export type PermissionSetting = ('granted' | 'denied');
 
         /**
          * Definition of PermissionDescriptor defined in the Permissions API:


### PR DESCRIPTION
The DevTools protocol[1] allows permissions for websites to be
overriden. As well as "granted"/"denied" the override could also be for
"prompt"[2], which should have forced the permission re-requested every
time. In practice however, the "prompt" override wasn't working
correctly. The changes required to fix that proved to be too invasive[3],
so we decided[4] to remove the option instead.

1 - https://chromedevtools.github.io/devtools-protocol/tot/Browser/#method-setPermission
2 - https://chromedevtools.github.io/devtools-protocol/tot/Browser/#type-PermissionSetting
3 - https://chromium-review.googlesource.com/c/chromium/src/+/3683443
4 - https://crbug.com/1319943#c13