### PR TITLE
Update loaderId description for requestWillBeSent and responseReceived network events

### DIFF
--- a/json/browser_protocol.json
+++ b/json/browser_protocol.json
@@ -15460,7 +15460,7 @@
                         },
                         {
                             "name": "loaderId",
-                            "description": "Loader identifier. Empty string if the request is fetched from worker.",
+                            "description": "Loader identifier. Empty string for a preflight request or if the request is fetched from a worker.",
                             "$ref": "LoaderId"
                         },
                         {
@@ -15570,7 +15570,7 @@
                         },
                         {
                             "name": "loaderId",
-                            "description": "Loader identifier. Empty string if the request is fetched from worker.",
+                            "description": "Loader identifier. Empty string for a preflight request or if the request is fetched from a worker.",
                             "$ref": "LoaderId"
                         },
                         {

--- a/pdl/browser_protocol.pdl
+++ b/pdl/browser_protocol.pdl
@@ -7114,7 +7114,7 @@ domain Network
     parameters
       # Request identifier.
       RequestId requestId
-      # Loader identifier. Empty string if the request is fetched from worker.
+      # Loader identifier. Empty string for a preflight request or if the request is fetched from a worker.
       LoaderId loaderId
       # URL of the document this request is loaded for.
       string documentURL
@@ -7162,7 +7162,7 @@ domain Network
     parameters
       # Request identifier.
       RequestId requestId
-      # Loader identifier. Empty string if the request is fetched from worker.
+      # Loader identifier. Empty string for a preflight request or if the request is fetched from a worker.
       LoaderId loaderId
       # Timestamp.
       MonotonicTime timestamp

--- a/types/protocol.d.ts
+++ b/types/protocol.d.ts
@@ -12267,7 +12267,7 @@ export namespace Protocol {
              */
             requestId: RequestId;
             /**
-             * Loader identifier. Empty string if the request is fetched from worker.
+             * Loader identifier. Empty string for a preflight request or if the request is fetched from a worker.
              */
             loaderId: LoaderId;
             /**
@@ -12355,7 +12355,7 @@ export namespace Protocol {
              */
             requestId: RequestId;
             /**
-             * Loader identifier. Empty string if the request is fetched from worker.
+             * Loader identifier. Empty string for a preflight request or if the request is fetched from a worker.
              */
             loaderId: LoaderId;
             /**


### PR DESCRIPTION
Updated the `loaderId` description in the `Network.requestWillBeSent` and `Network.responseReceived` events to mention that they might be empty for preflight requests, not just worker requests. Thought this would make things clearer for anyone digging into network request details.