### PR TITLE
feat: support `deprecated` and `experimental` in TSDoc

### DIFF
--- a/scripts/protocol-schema.d.ts
+++ b/scripts/protocol-schema.d.ts
@@ -4,13 +4,18 @@ export interface IProtocol {
     domains: Protocol.Domain[]
 }
 
-export module Protocol {
+export namespace Protocol {
     export interface Version {
         major: string
         minor: string
     }
 
-    export interface Domain {
+    export interface ExtraInformation {
+        deprecated?: boolean;
+        experimental?: boolean;
+    }
+
+    export interface Domain extends ExtraInformation {
         /** Name of domain */
         domain: string
         /** Description of the domain */
@@ -31,7 +36,7 @@ export module Protocol {
         redirect?: string
     }
 
-    export interface Event {
+    export interface Event extends ExtraInformation {
         name: string
         parameters?: PropertyType[]
         /** Description of the event */
@@ -86,9 +91,9 @@ export module Protocol {
         id: string
         /** Description of the type */
         description?: string
-    } & (StringType | ObjectType | ArrayType | PrimitiveType)
+    } & (StringType | ObjectType | ArrayType | PrimitiveType) & ExtraInformation;
 
-    type ProtocolType = StringType | ObjectType | ArrayType | PrimitiveType | RefType  | AnyType
+    type ProtocolType = StringType | ObjectType | ArrayType | PrimitiveType | RefType  | AnyType;
 
-    type PropertyType = PropertyBaseType & ProtocolType
+    type PropertyType = PropertyBaseType & ProtocolType;
 }

--- a/types/protocol-proxy-api.d.ts
+++ b/types/protocol-proxy-api.d.ts
@@ -176,6 +176,9 @@ export namespace ProtocolProxyApi {
          */
         getScriptSource(params: Protocol.Debugger.GetScriptSourceRequest): Promise<Protocol.Debugger.GetScriptSourceResponse>;
 
+        /**
+         * @experimental
+         */
         disassembleWasmModule(params: Protocol.Debugger.DisassembleWasmModuleRequest): Promise<Protocol.Debugger.DisassembleWasmModuleResponse>;
 
         /**
@@ -183,16 +186,19 @@ export namespace ProtocolProxyApi {
          * stream. If disassembly is complete, this API will invalidate the streamId
          * and return an empty chunk. Any subsequent calls for the now invalid stream
          * will return errors.
+         * @experimental
          */
         nextWasmDisassemblyChunk(params: Protocol.Debugger.NextWasmDisassemblyChunkRequest): Promise<Protocol.Debugger.NextWasmDisassemblyChunkResponse>;
 
         /**
          * This command is deprecated. Use getScriptSource instead.
+         * @deprecated
          */
         getWasmBytecode(params: Protocol.Debugger.GetWasmBytecodeRequest): Promise<Protocol.Debugger.GetWasmBytecodeResponse>;
 
         /**
          * Returns stack trace with given `stackTraceId`.
+         * @experimental
          */
         getStackTrace(params: Protocol.Debugger.GetStackTraceRequest): Promise<Protocol.Debugger.GetStackTraceResponse>;
 
@@ -201,6 +207,10 @@ export namespace ProtocolProxyApi {
          */
         pause(): Promise<void>;
 
+        /**
+         * @deprecated
+         * @experimental
+         */
         pauseOnAsyncCall(params: Protocol.Debugger.PauseOnAsyncCallRequest): Promise<void>;
 
         /**
@@ -244,6 +254,7 @@ export namespace ProtocolProxyApi {
          * Replace previous blackbox execution contexts with passed ones. Forces backend to skip
          * stepping/pausing in scripts in these execution contexts. VM will try to leave blackboxed script by
          * performing 'step in' several times, finally resorting to 'step out' if unsuccessful.
+         * @experimental
          */
         setBlackboxExecutionContexts(params: Protocol.Debugger.SetBlackboxExecutionContextsRequest): Promise<void>;
 
@@ -251,6 +262,7 @@ export namespace ProtocolProxyApi {
          * Replace previous blackbox patterns with passed ones. Forces backend to skip stepping/pausing in
          * scripts with url matching one of the patterns. VM will try to leave blackboxed script by
          * performing 'step in' several times, finally resorting to 'step out' if unsuccessful.
+         * @experimental
          */
         setBlackboxPatterns(params: Protocol.Debugger.SetBlackboxPatternsRequest): Promise<void>;
 
@@ -259,6 +271,7 @@ export namespace ProtocolProxyApi {
          * scripts by performing 'step in' several times, finally resorting to 'step out' if unsuccessful.
          * Positions array contains positions where blackbox state is changed. First interval isn't
          * blackboxed. Array should be sorted.
+         * @experimental
          */
         setBlackboxedRanges(params: Protocol.Debugger.SetBlackboxedRangesRequest): Promise<void>;
 
@@ -284,6 +297,7 @@ export namespace ProtocolProxyApi {
          * Sets JavaScript breakpoint before each call to the given function.
          * If another function was created from the same source as a given one,
          * calling it will also trigger the breakpoint.
+         * @experimental
          */
         setBreakpointOnFunctionCall(params: Protocol.Debugger.SetBreakpointOnFunctionCallRequest): Promise<Protocol.Debugger.SetBreakpointOnFunctionCallResponse>;
 
@@ -300,6 +314,7 @@ export namespace ProtocolProxyApi {
 
         /**
          * Changes return value in top frame. Available only at return break position.
+         * @experimental
          */
         setReturnValue(params: Protocol.Debugger.SetReturnValueRequest): Promise<void>;
 
@@ -343,6 +358,7 @@ export namespace ProtocolProxyApi {
         /**
          * Fired when breakpoint is resolved to an actual script and location.
          * Deprecated in favor of `resolvedBreakpoints` in the `scriptParsed` event.
+         * @deprecated
          */
         on(event: 'breakpointResolved', listener: (params: Protocol.Debugger.BreakpointResolvedEvent) => void): void;
 
@@ -469,6 +485,7 @@ export namespace ProtocolProxyApi {
          * `takePreciseCoverage` for the current isolate. May only be sent if precise code
          * coverage has been started. This event can be trigged by the embedder to, for example,
          * trigger collection of coverage data immediately at a certain point in time.
+         * @experimental
          */
         on(event: 'preciseCoverageDeltaUpdate', listener: (params: Protocol.Profiler.PreciseCoverageDeltaUpdateEvent) => void): void;
 
@@ -515,12 +532,14 @@ export namespace ProtocolProxyApi {
 
         /**
          * Returns the isolate id.
+         * @experimental
          */
         getIsolateId(): Promise<Protocol.Runtime.GetIsolateIdResponse>;
 
         /**
          * Returns the JavaScript heap usage.
          * It is the total usage of the corresponding isolate not scoped to a particular Runtime.
+         * @experimental
          */
         getHeapUsage(): Promise<Protocol.Runtime.GetHeapUsageResponse>;
 
@@ -562,13 +581,20 @@ export namespace ProtocolProxyApi {
          */
         setAsyncCallStackDepth(params: Protocol.Runtime.SetAsyncCallStackDepthRequest): Promise<void>;
 
+        /**
+         * @experimental
+         */
         setCustomObjectFormatterEnabled(params: Protocol.Runtime.SetCustomObjectFormatterEnabledRequest): Promise<void>;
 
+        /**
+         * @experimental
+         */
         setMaxCallStackSizeToCapture(params: Protocol.Runtime.SetMaxCallStackSizeToCaptureRequest): Promise<void>;
 
         /**
          * Terminate current or next JavaScript execution.
          * Will cancel the termination when the outer-most script execution ends.
+         * @experimental
          */
         terminateExecution(): Promise<void>;
 
@@ -594,11 +620,13 @@ export namespace ProtocolProxyApi {
          * Note that the stackTrace portion of the resulting exceptionDetails will
          * only be populated if the Runtime domain was enabled at the time when the
          * Error was thrown.
+         * @experimental
          */
         getExceptionDetails(params: Protocol.Runtime.GetExceptionDetailsRequest): Promise<Protocol.Runtime.GetExceptionDetailsResponse>;
 
         /**
          * Notification is issued every time when binding is called.
+         * @experimental
          */
         on(event: 'bindingCalled', listener: (params: Protocol.Runtime.BindingCalledEvent) => void): void;
 
@@ -662,29 +690,34 @@ export namespace ProtocolProxyApi {
 
         /**
          * Fetches the accessibility node and partial accessibility tree for this DOM node, if it exists.
+         * @experimental
          */
         getPartialAXTree(params: Protocol.Accessibility.GetPartialAXTreeRequest): Promise<Protocol.Accessibility.GetPartialAXTreeResponse>;
 
         /**
          * Fetches the entire accessibility tree for the root Document
+         * @experimental
          */
         getFullAXTree(params: Protocol.Accessibility.GetFullAXTreeRequest): Promise<Protocol.Accessibility.GetFullAXTreeResponse>;
 
         /**
          * Fetches the root node.
          * Requires `enable()` to have been called previously.
+         * @experimental
          */
         getRootAXNode(params: Protocol.Accessibility.GetRootAXNodeRequest): Promise<Protocol.Accessibility.GetRootAXNodeResponse>;
 
         /**
          * Fetches a node and all ancestors up to and including the root.
          * Requires `enable()` to have been called previously.
+         * @experimental
          */
         getAXNodeAndAncestors(params: Protocol.Accessibility.GetAXNodeAndAncestorsRequest): Promise<Protocol.Accessibility.GetAXNodeAndAncestorsResponse>;
 
         /**
          * Fetches a particular accessibility node by AXNodeId.
          * Requires `enable()` to have been called previously.
+         * @experimental
          */
         getChildAXNodes(params: Protocol.Accessibility.GetChildAXNodesRequest): Promise<Protocol.Accessibility.GetChildAXNodesResponse>;
 
@@ -694,17 +727,20 @@ export namespace ProtocolProxyApi {
          * ignored for accessibility, and returns those that match the specified name and role. If no DOM
          * node is specified, or the DOM node does not exist, the command returns an error. If neither
          * `accessibleName` or `role` is specified, it returns all the accessibility nodes in the subtree.
+         * @experimental
          */
         queryAXTree(params: Protocol.Accessibility.QueryAXTreeRequest): Promise<Protocol.Accessibility.QueryAXTreeResponse>;
 
         /**
          * The loadComplete event mirrors the load complete event sent by the browser to assistive
          * technology when the web page has finished loading.
+         * @experimental
          */
         on(event: 'loadComplete', listener: (params: Protocol.Accessibility.LoadCompleteEvent) => void): void;
 
         /**
          * The nodesUpdated event is sent every time a previously requested node has changed the in tree.
+         * @experimental
          */
         on(event: 'nodesUpdated', listener: (params: Protocol.Accessibility.NodesUpdatedEvent) => void): void;
 
@@ -924,11 +960,13 @@ export namespace ProtocolProxyApi {
     export interface BrowserApi {
         /**
          * Set permission settings for given origin.
+         * @experimental
          */
         setPermission(params: Protocol.Browser.SetPermissionRequest): Promise<void>;
 
         /**
          * Grant specific permissions to the given origin and reject all others.
+         * @experimental
          */
         grantPermissions(params: Protocol.Browser.GrantPermissionsRequest): Promise<void>;
 
@@ -939,11 +977,13 @@ export namespace ProtocolProxyApi {
 
         /**
          * Set the behavior when downloading a file.
+         * @experimental
          */
         setDownloadBehavior(params: Protocol.Browser.SetDownloadBehaviorRequest): Promise<void>;
 
         /**
          * Cancel a download if in progress
+         * @experimental
          */
         cancelDownload(params: Protocol.Browser.CancelDownloadRequest): Promise<void>;
 
@@ -954,11 +994,13 @@ export namespace ProtocolProxyApi {
 
         /**
          * Crashes browser on the main thread.
+         * @experimental
          */
         crash(): Promise<void>;
 
         /**
          * Crashes GPU process.
+         * @experimental
          */
         crashGpuProcess(): Promise<void>;
 
@@ -970,46 +1012,55 @@ export namespace ProtocolProxyApi {
         /**
          * Returns the command line switches for the browser process if, and only if
          * --enable-automation is on the commandline.
+         * @experimental
          */
         getBrowserCommandLine(): Promise<Protocol.Browser.GetBrowserCommandLineResponse>;
 
         /**
          * Get Chrome histograms.
+         * @experimental
          */
         getHistograms(params: Protocol.Browser.GetHistogramsRequest): Promise<Protocol.Browser.GetHistogramsResponse>;
 
         /**
          * Get a Chrome histogram by name.
+         * @experimental
          */
         getHistogram(params: Protocol.Browser.GetHistogramRequest): Promise<Protocol.Browser.GetHistogramResponse>;
 
         /**
          * Get position and size of the browser window.
+         * @experimental
          */
         getWindowBounds(params: Protocol.Browser.GetWindowBoundsRequest): Promise<Protocol.Browser.GetWindowBoundsResponse>;
 
         /**
          * Get the browser window that contains the devtools target.
+         * @experimental
          */
         getWindowForTarget(params: Protocol.Browser.GetWindowForTargetRequest): Promise<Protocol.Browser.GetWindowForTargetResponse>;
 
         /**
          * Set position and/or size of the browser window.
+         * @experimental
          */
         setWindowBounds(params: Protocol.Browser.SetWindowBoundsRequest): Promise<void>;
 
         /**
          * Set size of the browser contents resizing browser window as necessary.
+         * @experimental
          */
         setContentsSize(params: Protocol.Browser.SetContentsSizeRequest): Promise<void>;
 
         /**
          * Set dock tile details, platform-specific.
+         * @experimental
          */
         setDockTile(params: Protocol.Browser.SetDockTileRequest): Promise<void>;
 
         /**
          * Invoke custom browser commands used by telemetry.
+         * @experimental
          */
         executeBrowserCommand(params: Protocol.Browser.ExecuteBrowserCommandRequest): Promise<void>;
 
@@ -1029,11 +1080,13 @@ export namespace ProtocolProxyApi {
 
         /**
          * Fired when page is about to start a download.
+         * @experimental
          */
         on(event: 'downloadWillBegin', listener: (params: Protocol.Browser.DownloadWillBeginEvent) => void): void;
 
         /**
          * Fired when download makes progress. Last call has |done| == true.
+         * @experimental
          */
         on(event: 'downloadProgress', listener: (params: Protocol.Browser.DownloadProgressEvent) => void): void;
 
@@ -1095,9 +1148,13 @@ export namespace ProtocolProxyApi {
          * to the provided property syntax, the value is parsed using combined
          * syntax as if null `propertyName` was provided. If the value cannot be
          * resolved even then, return the provided value without any changes.
+         * @experimental
          */
         resolveValues(params: Protocol.CSS.ResolveValuesRequest): Promise<Protocol.CSS.ResolveValuesResponse>;
 
+        /**
+         * @experimental
+         */
         getLonghandProperties(params: Protocol.CSS.GetLonghandPropertiesRequest): Promise<Protocol.CSS.GetLonghandPropertiesResponse>;
 
         /**
@@ -1109,6 +1166,7 @@ export namespace ProtocolProxyApi {
         /**
          * Returns the styles coming from animations & transitions
          * including the animation & transition styles coming from inheritance chain.
+         * @experimental
          */
         getAnimatedStylesForNode(params: Protocol.CSS.GetAnimatedStylesForNodeRequest): Promise<Protocol.CSS.GetAnimatedStylesForNodeResponse>;
 
@@ -1119,6 +1177,7 @@ export namespace ProtocolProxyApi {
 
         /**
          * Returns the values of the default UA-defined environment variables used in env()
+         * @experimental
          */
         getEnvironmentVariables(): Promise<Protocol.CSS.GetEnvironmentVariablesResponse>;
 
@@ -1143,12 +1202,14 @@ export namespace ProtocolProxyApi {
          * Given a DOM element identified by nodeId, getLayersForNode returns the root
          * layer for the nearest ancestor document or shadow root. The layer root contains
          * the full layer tree for the tree scope and their ordering.
+         * @experimental
          */
         getLayersForNode(params: Protocol.CSS.GetLayersForNodeRequest): Promise<Protocol.CSS.GetLayersForNodeResponse>;
 
         /**
          * Given a CSS selector text and a style sheet ID, getLocationForSelector
          * returns an array of locations of the CSS selector in the style sheet.
+         * @experimental
          */
         getLocationForSelector(params: Protocol.CSS.GetLocationForSelectorRequest): Promise<Protocol.CSS.GetLocationForSelectorResponse>;
 
@@ -1159,6 +1220,7 @@ export namespace ProtocolProxyApi {
          * There can only be 1 node tracked for computed style updates
          * so passing a new node id removes tracking from the previous node.
          * Pass `undefined` to disable tracking.
+         * @experimental
          */
         trackComputedStyleUpdatesForNode(params: Protocol.CSS.TrackComputedStyleUpdatesForNodeRequest): Promise<void>;
 
@@ -1169,11 +1231,13 @@ export namespace ProtocolProxyApi {
          * The changes to computed style properties are only tracked for nodes pushed to the front-end
          * by the DOM agent. If no changes to the tracked properties occur after the node has been pushed
          * to the front-end, no updates will be issued for the node.
+         * @experimental
          */
         trackComputedStyleUpdates(params: Protocol.CSS.TrackComputedStyleUpdatesRequest): Promise<void>;
 
         /**
          * Polls the next batch of computed style updates.
+         * @experimental
          */
         takeComputedStyleUpdates(): Promise<Protocol.CSS.TakeComputedStyleUpdatesResponse>;
 
@@ -1200,16 +1264,19 @@ export namespace ProtocolProxyApi {
 
         /**
          * Modifies the expression of a container query.
+         * @experimental
          */
         setContainerQueryText(params: Protocol.CSS.SetContainerQueryTextRequest): Promise<Protocol.CSS.SetContainerQueryTextResponse>;
 
         /**
          * Modifies the expression of a supports at-rule.
+         * @experimental
          */
         setSupportsText(params: Protocol.CSS.SetSupportsTextRequest): Promise<Protocol.CSS.SetSupportsTextResponse>;
 
         /**
          * Modifies the expression of a scope at-rule.
+         * @experimental
          */
         setScopeText(params: Protocol.CSS.SetScopeTextRequest): Promise<Protocol.CSS.SetScopeTextResponse>;
 
@@ -1247,6 +1314,7 @@ export namespace ProtocolProxyApi {
 
         /**
          * Enables/disables rendering of local CSS fonts (enabled by default).
+         * @experimental
          */
         setLocalFontsEnabled(params: Protocol.CSS.SetLocalFontsEnabledRequest): Promise<void>;
 
@@ -1277,6 +1345,9 @@ export namespace ProtocolProxyApi {
          */
         on(event: 'styleSheetRemoved', listener: (params: Protocol.CSS.StyleSheetRemovedEvent) => void): void;
 
+        /**
+         * @experimental
+         */
         on(event: 'computedStyleUpdated', listener: (params: Protocol.CSS.ComputedStyleUpdatedEvent) => void): void;
 
     }
@@ -1362,12 +1433,14 @@ export namespace ProtocolProxyApi {
     export interface DOMApi {
         /**
          * Collects class names for the node with given id and all of it's child nodes.
+         * @experimental
          */
         collectClassNamesFromSubtree(params: Protocol.DOM.CollectClassNamesFromSubtreeRequest): Promise<Protocol.DOM.CollectClassNamesFromSubtreeResponse>;
 
         /**
          * Creates a deep copy of the specified node and places it into the target container before the
          * given anchor.
+         * @experimental
          */
         copyTo(params: Protocol.DOM.CopyToRequest): Promise<Protocol.DOM.CopyToResponse>;
 
@@ -1392,6 +1465,7 @@ export namespace ProtocolProxyApi {
         /**
          * Discards search results from the session with the given id. `getSearchResults` should no longer
          * be called for that search.
+         * @experimental
          */
         discardSearchResults(params: Protocol.DOM.DiscardSearchResultsRequest): Promise<void>;
 
@@ -1418,6 +1492,7 @@ export namespace ProtocolProxyApi {
         /**
          * Returns quads that describe node position on the page. This method
          * might return multiple quads for inline nodes.
+         * @experimental
          */
         getContentQuads(params: Protocol.DOM.GetContentQuadsRequest): Promise<Protocol.DOM.GetContentQuadsResponse>;
 
@@ -1431,11 +1506,13 @@ export namespace ProtocolProxyApi {
          * Returns the root DOM node (and optionally the subtree) to the caller.
          * Deprecated, as it is not designed to work well with the rest of the DOM agent.
          * Use DOMSnapshot.captureSnapshot instead.
+         * @deprecated
          */
         getFlattenedDocument(params: Protocol.DOM.GetFlattenedDocumentRequest): Promise<Protocol.DOM.GetFlattenedDocumentResponse>;
 
         /**
          * Finds nodes with a given computed style in a subtree.
+         * @experimental
          */
         getNodesForSubtreeByStyle(params: Protocol.DOM.GetNodesForSubtreeByStyleRequest): Promise<Protocol.DOM.GetNodesForSubtreeByStyleResponse>;
 
@@ -1452,12 +1529,14 @@ export namespace ProtocolProxyApi {
 
         /**
          * Returns the id of the nearest ancestor that is a relayout boundary.
+         * @experimental
          */
         getRelayoutBoundary(params: Protocol.DOM.GetRelayoutBoundaryRequest): Promise<Protocol.DOM.GetRelayoutBoundaryResponse>;
 
         /**
          * Returns search results from given `fromIndex` to given `toIndex` from the search with the given
          * identifier.
+         * @experimental
          */
         getSearchResults(params: Protocol.DOM.GetSearchResultsRequest): Promise<Protocol.DOM.GetSearchResultsResponse>;
 
@@ -1478,6 +1557,7 @@ export namespace ProtocolProxyApi {
 
         /**
          * Marks last undoable state.
+         * @experimental
          */
         markUndoableState(): Promise<void>;
 
@@ -1489,16 +1569,19 @@ export namespace ProtocolProxyApi {
         /**
          * Searches for a given string in the DOM tree. Use `getSearchResults` to access search results or
          * `cancelSearch` to end this search session.
+         * @experimental
          */
         performSearch(params: Protocol.DOM.PerformSearchRequest): Promise<Protocol.DOM.PerformSearchResponse>;
 
         /**
          * Requests that the node is sent to the caller given its path. // FIXME, use XPath
+         * @experimental
          */
         pushNodeByPathToFrontend(params: Protocol.DOM.PushNodeByPathToFrontendRequest): Promise<Protocol.DOM.PushNodeByPathToFrontendResponse>;
 
         /**
          * Requests that a batch of nodes is sent to the caller given their backend node ids.
+         * @experimental
          */
         pushNodesByBackendIdsToFrontend(params: Protocol.DOM.PushNodesByBackendIdsToFrontendRequest): Promise<Protocol.DOM.PushNodesByBackendIdsToFrontendResponse>;
 
@@ -1516,16 +1599,19 @@ export namespace ProtocolProxyApi {
          * Returns NodeIds of current top layer elements.
          * Top layer is rendered closest to the user within a viewport, therefore its elements always
          * appear on top of all other content.
+         * @experimental
          */
         getTopLayerElements(): Promise<Protocol.DOM.GetTopLayerElementsResponse>;
 
         /**
          * Returns the NodeId of the matched element according to certain relations.
+         * @experimental
          */
         getElementByRelation(params: Protocol.DOM.GetElementByRelationRequest): Promise<Protocol.DOM.GetElementByRelationResponse>;
 
         /**
          * Re-does the last undone action.
+         * @experimental
          */
         redo(): Promise<void>;
 
@@ -1576,28 +1662,33 @@ export namespace ProtocolProxyApi {
 
         /**
          * Sets if stack traces should be captured for Nodes. See `Node.getNodeStackTraces`. Default is disabled.
+         * @experimental
          */
         setNodeStackTracesEnabled(params: Protocol.DOM.SetNodeStackTracesEnabledRequest): Promise<void>;
 
         /**
          * Gets stack traces associated with a Node. As of now, only provides stack trace for Node creation.
+         * @experimental
          */
         getNodeStackTraces(params: Protocol.DOM.GetNodeStackTracesRequest): Promise<Protocol.DOM.GetNodeStackTracesResponse>;
 
         /**
          * Returns file information for the given
          * File wrapper.
+         * @experimental
          */
         getFileInfo(params: Protocol.DOM.GetFileInfoRequest): Promise<Protocol.DOM.GetFileInfoResponse>;
 
         /**
          * Returns list of detached nodes
+         * @experimental
          */
         getDetachedDomNodes(): Promise<Protocol.DOM.GetDetachedDomNodesResponse>;
 
         /**
          * Enables console to refer to the node with given id via $x (see Command Line API for more details
          * $x functions).
+         * @experimental
          */
         setInspectedNode(params: Protocol.DOM.SetInspectedNodeRequest): Promise<void>;
 
@@ -1618,11 +1709,13 @@ export namespace ProtocolProxyApi {
 
         /**
          * Undoes the last performed action.
+         * @experimental
          */
         undo(): Promise<void>;
 
         /**
          * Returns iframe node that owns iframe with the given domain.
+         * @experimental
          */
         getFrameOwner(params: Protocol.DOM.GetFrameOwnerRequest): Promise<Protocol.DOM.GetFrameOwnerResponse>;
 
@@ -1632,24 +1725,28 @@ export namespace ProtocolProxyApi {
          * scroll-state or anchored elements. If no axes are provided and
          * queriesScrollState is false, the style container is returned, which is the
          * direct parent or the closest element with a matching container-name.
+         * @experimental
          */
         getContainerForNode(params: Protocol.DOM.GetContainerForNodeRequest): Promise<Protocol.DOM.GetContainerForNodeResponse>;
 
         /**
          * Returns the descendants of a container query container that have
          * container queries against this container.
+         * @experimental
          */
         getQueryingDescendantsForContainer(params: Protocol.DOM.GetQueryingDescendantsForContainerRequest): Promise<Protocol.DOM.GetQueryingDescendantsForContainerResponse>;
 
         /**
          * Returns the target anchor element of the given anchor query according to
          * https://www.w3.org/TR/css-anchor-position-1/#target.
+         * @experimental
          */
         getAnchorElement(params: Protocol.DOM.GetAnchorElementRequest): Promise<Protocol.DOM.GetAnchorElementResponse>;
 
         /**
          * When enabling, this API force-opens the popover identified by nodeId
          * and keeps it open until disabled.
+         * @experimental
          */
         forceShowPopover(params: Protocol.DOM.ForceShowPopoverRequest): Promise<Protocol.DOM.ForceShowPopoverResponse>;
 
@@ -1685,6 +1782,7 @@ export namespace ProtocolProxyApi {
 
         /**
          * Called when distribution is changed.
+         * @experimental
          */
         on(event: 'distributedNodesUpdated', listener: (params: Protocol.DOM.DistributedNodesUpdatedEvent) => void): void;
 
@@ -1695,26 +1793,31 @@ export namespace ProtocolProxyApi {
 
         /**
          * Fired when `Element`'s inline style is modified via a CSS property modification.
+         * @experimental
          */
         on(event: 'inlineStyleInvalidated', listener: (params: Protocol.DOM.InlineStyleInvalidatedEvent) => void): void;
 
         /**
          * Called when a pseudo element is added to an element.
+         * @experimental
          */
         on(event: 'pseudoElementAdded', listener: (params: Protocol.DOM.PseudoElementAddedEvent) => void): void;
 
         /**
          * Called when top layer elements are changed.
+         * @experimental
          */
         on(event: 'topLayerElementsUpdated', listener: () => void): void;
 
         /**
          * Fired when a node's scrollability state changes.
+         * @experimental
          */
         on(event: 'scrollableFlagUpdated', listener: (params: Protocol.DOM.ScrollableFlagUpdatedEvent) => void): void;
 
         /**
          * Called when a pseudo element is removed from an element.
+         * @experimental
          */
         on(event: 'pseudoElementRemoved', listener: (params: Protocol.DOM.PseudoElementRemovedEvent) => void): void;
 
@@ -1726,11 +1829,13 @@ export namespace ProtocolProxyApi {
 
         /**
          * Called when shadow root is popped from the element.
+         * @experimental
          */
         on(event: 'shadowRootPopped', listener: (params: Protocol.DOM.ShadowRootPoppedEvent) => void): void;
 
         /**
          * Called when shadow root is pushed into the element.
+         * @experimental
          */
         on(event: 'shadowRootPushed', listener: (params: Protocol.DOM.ShadowRootPushedEvent) => void): void;
 
@@ -1754,6 +1859,8 @@ export namespace ProtocolProxyApi {
 
         /**
          * Removes breakpoint on particular native event.
+         * @deprecated
+         * @experimental
          */
         removeInstrumentationBreakpoint(params: Protocol.DOMDebugger.RemoveInstrumentationBreakpointRequest): Promise<void>;
 
@@ -1764,6 +1871,7 @@ export namespace ProtocolProxyApi {
 
         /**
          * Sets breakpoint on particular CSP violations.
+         * @experimental
          */
         setBreakOnCSPViolation(params: Protocol.DOMDebugger.SetBreakOnCSPViolationRequest): Promise<void>;
 
@@ -1779,6 +1887,8 @@ export namespace ProtocolProxyApi {
 
         /**
          * Sets breakpoint on particular native event.
+         * @deprecated
+         * @experimental
          */
         setInstrumentationBreakpoint(params: Protocol.DOMDebugger.SetInstrumentationBreakpointRequest): Promise<void>;
 
@@ -1823,6 +1933,7 @@ export namespace ProtocolProxyApi {
          * template contents, and imported documents) in a flattened array, as well as layout and
          * white-listed computed style information for the nodes. Shadow DOM in the returned DOM tree is
          * flattened.
+         * @deprecated
          */
         getSnapshot(params: Protocol.DOMSnapshot.GetSnapshotRequest): Promise<Protocol.DOMSnapshot.GetSnapshotResponse>;
 
@@ -1881,6 +1992,7 @@ export namespace ProtocolProxyApi {
     export interface EmulationApi {
         /**
          * Tells whether emulation is supported.
+         * @deprecated
          */
         canEmulate(): Promise<Protocol.Emulation.CanEmulateResponse>;
 
@@ -1896,16 +2008,19 @@ export namespace ProtocolProxyApi {
 
         /**
          * Requests that page scale factor is reset to initial values.
+         * @experimental
          */
         resetPageScaleFactor(): Promise<void>;
 
         /**
          * Enables or disables simulating a focused and active page.
+         * @experimental
          */
         setFocusEmulationEnabled(params: Protocol.Emulation.SetFocusEmulationEnabledRequest): Promise<void>;
 
         /**
          * Automatically render all web contents using a dark theme.
+         * @experimental
          */
         setAutoDarkModeOverride(params: Protocol.Emulation.SetAutoDarkModeOverrideRequest): Promise<void>;
 
@@ -1923,6 +2038,7 @@ export namespace ProtocolProxyApi {
         /**
          * Overrides the values for env(safe-area-inset-*) and env(safe-area-max-inset-*). Unset values will cause the
          * respective variables to be undefined, even if previously overridden.
+         * @experimental
          */
         setSafeAreaInsetsOverride(params: Protocol.Emulation.SetSafeAreaInsetsOverrideRequest): Promise<void>;
 
@@ -1936,6 +2052,7 @@ export namespace ProtocolProxyApi {
         /**
          * Start reporting the given posture value to the Device Posture API.
          * This override can also be set in setDeviceMetricsOverride().
+         * @experimental
          */
         setDevicePostureOverride(params: Protocol.Emulation.SetDevicePostureOverrideRequest): Promise<void>;
 
@@ -1944,12 +2061,14 @@ export namespace ProtocolProxyApi {
          * or setDevicePostureOverride() and starts using posture information from the
          * platform again.
          * Does nothing if no override is set.
+         * @experimental
          */
         clearDevicePostureOverride(): Promise<void>;
 
         /**
          * Start using the given display features to pupulate the Viewport Segments API.
          * This override can also be set in setDeviceMetricsOverride().
+         * @experimental
          */
         setDisplayFeaturesOverride(params: Protocol.Emulation.SetDisplayFeaturesOverrideRequest): Promise<void>;
 
@@ -1958,13 +2077,23 @@ export namespace ProtocolProxyApi {
          * or setDisplayFeaturesOverride() and starts using display features from the
          * platform again.
          * Does nothing if no override is set.
+         * @experimental
          */
         clearDisplayFeaturesOverride(): Promise<void>;
 
+        /**
+         * @experimental
+         */
         setScrollbarsHidden(params: Protocol.Emulation.SetScrollbarsHiddenRequest): Promise<void>;
 
+        /**
+         * @experimental
+         */
         setDocumentCookieDisabled(params: Protocol.Emulation.SetDocumentCookieDisabledRequest): Promise<void>;
 
+        /**
+         * @experimental
+         */
         setEmitTouchEventsForMouse(params: Protocol.Emulation.SetEmitTouchEventsForMouseRequest): Promise<void>;
 
         /**
@@ -1988,6 +2117,9 @@ export namespace ProtocolProxyApi {
          */
         setGeolocationOverride(params: Protocol.Emulation.SetGeolocationOverrideRequest): Promise<void>;
 
+        /**
+         * @experimental
+         */
         getOverriddenSensorInformation(params: Protocol.Emulation.GetOverriddenSensorInformationRequest): Promise<Protocol.Emulation.GetOverriddenSensorInformationResponse>;
 
         /**
@@ -1996,12 +2128,14 @@ export namespace ProtocolProxyApi {
          * data from a real hardware sensor. Otherwise, existing virtual
          * sensor-backend Sensor objects will fire an error event and new calls to
          * Sensor.start() will attempt to use a real sensor instead.
+         * @experimental
          */
         setSensorOverrideEnabled(params: Protocol.Emulation.SetSensorOverrideEnabledRequest): Promise<void>;
 
         /**
          * Updates the sensor readings reported by a sensor type previously overridden
          * by setSensorOverrideEnabled.
+         * @experimental
          */
         setSensorOverrideReadings(params: Protocol.Emulation.SetSensorOverrideReadingsRequest): Promise<void>;
 
@@ -2010,6 +2144,7 @@ export namespace ProtocolProxyApi {
          * Pressure API, so that updates to PressureObserver.observe() are provided
          * via setPressureStateOverride instead of being retrieved from
          * platform-provided telemetry data.
+         * @experimental
          */
         setPressureSourceOverrideEnabled(params: Protocol.Emulation.SetPressureSourceOverrideEnabledRequest): Promise<void>;
 
@@ -2018,6 +2153,7 @@ export namespace ProtocolProxyApi {
          * Provides a given pressure state that will be processed and eventually be
          * delivered to PressureObserver users. |source| must have been previously
          * overridden by setPressureSourceOverrideEnabled.
+         * @experimental
          */
         setPressureStateOverride(params: Protocol.Emulation.SetPressureStateOverrideRequest): Promise<void>;
 
@@ -2025,6 +2161,7 @@ export namespace ProtocolProxyApi {
          * Provides a given pressure data set that will be processed and eventually be
          * delivered to PressureObserver users. |source| must have been previously
          * overridden by setPressureSourceOverrideEnabled.
+         * @experimental
          */
         setPressureDataOverride(params: Protocol.Emulation.SetPressureDataOverrideRequest): Promise<void>;
 
@@ -2040,11 +2177,14 @@ export namespace ProtocolProxyApi {
 
         /**
          * Overrides value returned by the javascript navigator object.
+         * @deprecated
+         * @experimental
          */
         setNavigatorOverrides(params: Protocol.Emulation.SetNavigatorOverridesRequest): Promise<void>;
 
         /**
          * Sets a specified page scale factor.
+         * @experimental
          */
         setPageScaleFactor(params: Protocol.Emulation.SetPageScaleFactorRequest): Promise<void>;
 
@@ -2061,11 +2201,13 @@ export namespace ProtocolProxyApi {
         /**
          * Turns on virtual time for all frames (replacing real-time with a synthetic time source) and sets
          * the current virtual time policy.  Note this supersedes any previous time budget.
+         * @experimental
          */
         setVirtualTimePolicy(params: Protocol.Emulation.SetVirtualTimePolicyRequest): Promise<Protocol.Emulation.SetVirtualTimePolicyResponse>;
 
         /**
          * Overrides default host system locale with the specified one.
+         * @experimental
          */
         setLocaleOverride(params: Protocol.Emulation.SetLocaleOverrideRequest): Promise<void>;
 
@@ -2078,16 +2220,25 @@ export namespace ProtocolProxyApi {
          * Resizes the frame/viewport of the page. Note that this does not affect the frame's container
          * (e.g. browser window). Can be used to produce screenshots of the specified size. Not supported
          * on Android.
+         * @deprecated
+         * @experimental
          */
         setVisibleSize(params: Protocol.Emulation.SetVisibleSizeRequest): Promise<void>;
 
+        /**
+         * @experimental
+         */
         setDisabledImageTypes(params: Protocol.Emulation.SetDisabledImageTypesRequest): Promise<void>;
 
         /**
          * Override the value of navigator.connection.saveData
+         * @experimental
          */
         setDataSaverOverride(params: Protocol.Emulation.SetDataSaverOverrideRequest): Promise<void>;
 
+        /**
+         * @experimental
+         */
         setHardwareConcurrencyOverride(params: Protocol.Emulation.SetHardwareConcurrencyOverrideRequest): Promise<void>;
 
         /**
@@ -2098,17 +2249,20 @@ export namespace ProtocolProxyApi {
 
         /**
          * Allows overriding the automation flag.
+         * @experimental
          */
         setAutomationOverride(params: Protocol.Emulation.SetAutomationOverrideRequest): Promise<void>;
 
         /**
          * Allows overriding the difference between the small and large viewport sizes, which determine the
          * value of the `svh` and `lvh` unit, respectively. Only supported for top-level frames.
+         * @experimental
          */
         setSmallViewportHeightDifferenceOverride(params: Protocol.Emulation.SetSmallViewportHeightDifferenceOverrideRequest): Promise<void>;
 
         /**
          * Notification sent after the virtual time budget for the current VirtualTimePolicy has run out.
+         * @experimental
          */
         on(event: 'virtualTimeBudgetExpired', listener: () => void): void;
 
@@ -2125,11 +2279,13 @@ export namespace ProtocolProxyApi {
 
         /**
          * Disables headless events for the target.
+         * @deprecated
          */
         disable(): Promise<void>;
 
         /**
          * Enables headless events for the target.
+         * @deprecated
          */
         enable(): Promise<void>;
 
@@ -2209,6 +2365,7 @@ export namespace ProtocolProxyApi {
     export interface InputApi {
         /**
          * Dispatches a drag event into the page.
+         * @experimental
          */
         dispatchDragEvent(params: Protocol.Input.DispatchDragEventRequest): Promise<void>;
 
@@ -2220,6 +2377,7 @@ export namespace ProtocolProxyApi {
         /**
          * This method emulates inserting text that doesn't come from a key press,
          * for example an emoji keyboard or an IME.
+         * @experimental
          */
         insertText(params: Protocol.Input.InsertTextRequest): Promise<void>;
 
@@ -2227,6 +2385,7 @@ export namespace ProtocolProxyApi {
          * This method sets the current candidate text for IME.
          * Use imeCommitComposition to commit the final text.
          * Use imeSetComposition with empty string as text to cancel composition.
+         * @experimental
          */
         imeSetComposition(params: Protocol.Input.ImeSetCompositionRequest): Promise<void>;
 
@@ -2247,6 +2406,7 @@ export namespace ProtocolProxyApi {
 
         /**
          * Emulates touch event from the mouse event parameters.
+         * @experimental
          */
         emulateTouchFromMouseEvent(params: Protocol.Input.EmulateTouchFromMouseEventRequest): Promise<void>;
 
@@ -2258,27 +2418,32 @@ export namespace ProtocolProxyApi {
         /**
          * Prevents default drag and drop behavior and instead emits `Input.dragIntercepted` events.
          * Drag and drop behavior can be directly controlled via `Input.dispatchDragEvent`.
+         * @experimental
          */
         setInterceptDrags(params: Protocol.Input.SetInterceptDragsRequest): Promise<void>;
 
         /**
          * Synthesizes a pinch gesture over a time period by issuing appropriate touch events.
+         * @experimental
          */
         synthesizePinchGesture(params: Protocol.Input.SynthesizePinchGestureRequest): Promise<void>;
 
         /**
          * Synthesizes a scroll gesture over a time period by issuing appropriate touch events.
+         * @experimental
          */
         synthesizeScrollGesture(params: Protocol.Input.SynthesizeScrollGestureRequest): Promise<void>;
 
         /**
          * Synthesizes a tap gesture over a time period by issuing appropriate touch events.
+         * @experimental
          */
         synthesizeTapGesture(params: Protocol.Input.SynthesizeTapGestureRequest): Promise<void>;
 
         /**
          * Emitted only when `Input.setInterceptDrags` is enabled. Use this data with `Input.dispatchDragEvent` to
          * restore normal drag and drop behavior.
+         * @experimental
          */
         on(event: 'dragIntercepted', listener: (params: Protocol.Input.DragInterceptedEvent) => void): void;
 
@@ -2460,26 +2625,31 @@ export namespace ProtocolProxyApi {
     export interface NetworkApi {
         /**
          * Sets a list of content encodings that will be accepted. Empty list means no encoding is accepted.
+         * @experimental
          */
         setAcceptedEncodings(params: Protocol.Network.SetAcceptedEncodingsRequest): Promise<void>;
 
         /**
          * Clears accepted encodings set by setAcceptedEncodings
+         * @experimental
          */
         clearAcceptedEncodingsOverride(): Promise<void>;
 
         /**
          * Tells whether clearing browser cache is supported.
+         * @deprecated
          */
         canClearBrowserCache(): Promise<Protocol.Network.CanClearBrowserCacheResponse>;
 
         /**
          * Tells whether clearing browser cookies is supported.
+         * @deprecated
          */
         canClearBrowserCookies(): Promise<Protocol.Network.CanClearBrowserCookiesResponse>;
 
         /**
          * Tells whether emulation of network conditions is supported.
+         * @deprecated
          */
         canEmulateNetworkConditions(): Promise<Protocol.Network.CanEmulateNetworkConditionsResponse>;
 
@@ -2499,6 +2669,8 @@ export namespace ProtocolProxyApi {
          * fetch occurs as a result which encounters a redirect an additional Network.requestIntercepted
          * event will be sent with the same InterceptionId.
          * Deprecated, use Fetch.continueRequest, Fetch.fulfillRequest and Fetch.failRequest instead.
+         * @deprecated
+         * @experimental
          */
         continueInterceptedRequest(params: Protocol.Network.ContinueInterceptedRequestRequest): Promise<void>;
 
@@ -2526,11 +2698,13 @@ export namespace ProtocolProxyApi {
          * Returns all browser cookies. Depending on the backend support, will return detailed cookie
          * information in the `cookies` field.
          * Deprecated. Use Storage.getCookies instead.
+         * @deprecated
          */
         getAllCookies(): Promise<Protocol.Network.GetAllCookiesResponse>;
 
         /**
          * Returns the DER-encoded certificate.
+         * @experimental
          */
         getCertificate(params: Protocol.Network.GetCertificateRequest): Promise<Protocol.Network.GetCertificateResponse>;
 
@@ -2552,6 +2726,7 @@ export namespace ProtocolProxyApi {
 
         /**
          * Returns content served for the given currently intercepted request.
+         * @experimental
          */
         getResponseBodyForInterception(params: Protocol.Network.GetResponseBodyForInterceptionRequest): Promise<Protocol.Network.GetResponseBodyForInterceptionResponse>;
 
@@ -2560,6 +2735,7 @@ export namespace ProtocolProxyApi {
          * the intercepted request can't be continued as is -- you either need to cancel it or to provide
          * the response body. The stream only supports sequential read, IO.read will fail if the position
          * is specified.
+         * @experimental
          */
         takeResponseBodyForInterceptionAsStream(params: Protocol.Network.TakeResponseBodyForInterceptionAsStreamRequest): Promise<Protocol.Network.TakeResponseBodyForInterceptionAsStreamResponse>;
 
@@ -2567,16 +2743,19 @@ export namespace ProtocolProxyApi {
          * This method sends a new XMLHttpRequest which is identical to the original one. The following
          * parameters should be identical: method, url, async, request body, extra headers, withCredentials
          * attribute, user, password.
+         * @experimental
          */
         replayXHR(params: Protocol.Network.ReplayXHRRequest): Promise<void>;
 
         /**
          * Searches for given string in response content.
+         * @experimental
          */
         searchInResponseBody(params: Protocol.Network.SearchInResponseBodyRequest): Promise<Protocol.Network.SearchInResponseBodyResponse>;
 
         /**
          * Blocks URLs from loading.
+         * @experimental
          */
         setBlockedURLs(params: Protocol.Network.SetBlockedURLsRequest): Promise<void>;
 
@@ -2607,12 +2786,15 @@ export namespace ProtocolProxyApi {
 
         /**
          * Specifies whether to attach a page script stack id in requests
+         * @experimental
          */
         setAttachDebugStack(params: Protocol.Network.SetAttachDebugStackRequest): Promise<void>;
 
         /**
          * Sets the requests to intercept that match the provided patterns and optionally resource types.
          * Deprecated, please use Fetch.enable instead.
+         * @deprecated
+         * @experimental
          */
         setRequestInterception(params: Protocol.Network.SetRequestInterceptionRequest): Promise<void>;
 
@@ -2624,28 +2806,33 @@ export namespace ProtocolProxyApi {
         /**
          * Enables streaming of the response for the given requestId.
          * If enabled, the dataReceived event contains the data that was received during streaming.
+         * @experimental
          */
         streamResourceContent(params: Protocol.Network.StreamResourceContentRequest): Promise<Protocol.Network.StreamResourceContentResponse>;
 
         /**
          * Returns information about the COEP/COOP isolation status.
+         * @experimental
          */
         getSecurityIsolationStatus(params: Protocol.Network.GetSecurityIsolationStatusRequest): Promise<Protocol.Network.GetSecurityIsolationStatusResponse>;
 
         /**
          * Enables tracking for the Reporting API, events generated by the Reporting API will now be delivered to the client.
          * Enabling triggers 'reportingApiReportAdded' for all existing reports.
+         * @experimental
          */
         enableReportingApi(params: Protocol.Network.EnableReportingApiRequest): Promise<void>;
 
         /**
          * Fetches the resource and returns the content.
+         * @experimental
          */
         loadNetworkResource(params: Protocol.Network.LoadNetworkResourceRequest): Promise<Protocol.Network.LoadNetworkResourceResponse>;
 
         /**
          * Sets Controls for third-party cookie access
          * Page reload is required before the new cookie behavior will be observed
+         * @experimental
          */
         setCookieControls(params: Protocol.Network.SetCookieControlsRequest): Promise<void>;
 
@@ -2673,6 +2860,8 @@ export namespace ProtocolProxyApi {
          * Details of an intercepted HTTP request, which must be either allowed, blocked, modified or
          * mocked.
          * Deprecated, use Fetch.requestPaused instead.
+         * @deprecated
+         * @experimental
          */
         on(event: 'requestIntercepted', listener: (params: Protocol.Network.RequestInterceptedEvent) => void): void;
 
@@ -2688,11 +2877,13 @@ export namespace ProtocolProxyApi {
 
         /**
          * Fired when resource loading priority is changed
+         * @experimental
          */
         on(event: 'resourceChangedPriority', listener: (params: Protocol.Network.ResourceChangedPriorityEvent) => void): void;
 
         /**
          * Fired when a signed exchange was received over the network
+         * @experimental
          */
         on(event: 'signedExchangeReceived', listener: (params: Protocol.Network.SignedExchangeReceivedEvent) => void): void;
 
@@ -2753,61 +2944,73 @@ export namespace ProtocolProxyApi {
 
         /**
          * Fired upon direct_socket.TCPSocket creation.
+         * @experimental
          */
         on(event: 'directTCPSocketCreated', listener: (params: Protocol.Network.DirectTCPSocketCreatedEvent) => void): void;
 
         /**
          * Fired when direct_socket.TCPSocket connection is opened.
+         * @experimental
          */
         on(event: 'directTCPSocketOpened', listener: (params: Protocol.Network.DirectTCPSocketOpenedEvent) => void): void;
 
         /**
          * Fired when direct_socket.TCPSocket is aborted.
+         * @experimental
          */
         on(event: 'directTCPSocketAborted', listener: (params: Protocol.Network.DirectTCPSocketAbortedEvent) => void): void;
 
         /**
          * Fired when direct_socket.TCPSocket is closed.
+         * @experimental
          */
         on(event: 'directTCPSocketClosed', listener: (params: Protocol.Network.DirectTCPSocketClosedEvent) => void): void;
 
         /**
          * Fired when data is sent to tcp direct socket stream.
+         * @experimental
          */
         on(event: 'directTCPSocketChunkSent', listener: (params: Protocol.Network.DirectTCPSocketChunkSentEvent) => void): void;
 
         /**
          * Fired when data is received from tcp direct socket stream.
+         * @experimental
          */
         on(event: 'directTCPSocketChunkReceived', listener: (params: Protocol.Network.DirectTCPSocketChunkReceivedEvent) => void): void;
 
         /**
          * Fired upon direct_socket.UDPSocket creation.
+         * @experimental
          */
         on(event: 'directUDPSocketCreated', listener: (params: Protocol.Network.DirectUDPSocketCreatedEvent) => void): void;
 
         /**
          * Fired when direct_socket.UDPSocket connection is opened.
+         * @experimental
          */
         on(event: 'directUDPSocketOpened', listener: (params: Protocol.Network.DirectUDPSocketOpenedEvent) => void): void;
 
         /**
          * Fired when direct_socket.UDPSocket is aborted.
+         * @experimental
          */
         on(event: 'directUDPSocketAborted', listener: (params: Protocol.Network.DirectUDPSocketAbortedEvent) => void): void;
 
         /**
          * Fired when direct_socket.UDPSocket is closed.
+         * @experimental
          */
         on(event: 'directUDPSocketClosed', listener: (params: Protocol.Network.DirectUDPSocketClosedEvent) => void): void;
 
         /**
          * Fired when message is sent to udp direct socket stream.
+         * @experimental
          */
         on(event: 'directUDPSocketChunkSent', listener: (params: Protocol.Network.DirectUDPSocketChunkSentEvent) => void): void;
 
         /**
          * Fired when message is received from udp direct socket stream.
+         * @experimental
          */
         on(event: 'directUDPSocketChunkReceived', listener: (params: Protocol.Network.DirectUDPSocketChunkReceivedEvent) => void): void;
 
@@ -2816,6 +3019,7 @@ export namespace ProtocolProxyApi {
          * network stack. Not every requestWillBeSent event will have an additional
          * requestWillBeSentExtraInfo fired for it, and there is no guarantee whether requestWillBeSent
          * or requestWillBeSentExtraInfo will be fired first for the same request.
+         * @experimental
          */
         on(event: 'requestWillBeSentExtraInfo', listener: (params: Protocol.Network.RequestWillBeSentExtraInfoEvent) => void): void;
 
@@ -2823,6 +3027,7 @@ export namespace ProtocolProxyApi {
          * Fired when additional information about a responseReceived event is available from the network
          * stack. Not every responseReceived event will have an additional responseReceivedExtraInfo for
          * it, and responseReceivedExtraInfo may be fired before or after responseReceived.
+         * @experimental
          */
         on(event: 'responseReceivedExtraInfo', listener: (params: Protocol.Network.ResponseReceivedExtraInfoEvent) => void): void;
 
@@ -2830,6 +3035,7 @@ export namespace ProtocolProxyApi {
          * Fired when 103 Early Hints headers is received in addition to the common response.
          * Not every responseReceived event will have an responseReceivedEarlyHints fired.
          * Only one responseReceivedEarlyHints may be fired for eached responseReceived event.
+         * @experimental
          */
         on(event: 'responseReceivedEarlyHints', listener: (params: Protocol.Network.ResponseReceivedEarlyHintsEvent) => void): void;
 
@@ -2838,44 +3044,57 @@ export namespace ProtocolProxyApi {
          * the type of the operation and whether the operation succeeded or
          * failed, the event is fired before the corresponding request was sent
          * or after the response was received.
+         * @experimental
          */
         on(event: 'trustTokenOperationDone', listener: (params: Protocol.Network.TrustTokenOperationDoneEvent) => void): void;
 
         /**
          * Fired once security policy has been updated.
+         * @experimental
          */
         on(event: 'policyUpdated', listener: () => void): void;
 
         /**
          * Fired once when parsing the .wbn file has succeeded.
          * The event contains the information about the web bundle contents.
+         * @experimental
          */
         on(event: 'subresourceWebBundleMetadataReceived', listener: (params: Protocol.Network.SubresourceWebBundleMetadataReceivedEvent) => void): void;
 
         /**
          * Fired once when parsing the .wbn file has failed.
+         * @experimental
          */
         on(event: 'subresourceWebBundleMetadataError', listener: (params: Protocol.Network.SubresourceWebBundleMetadataErrorEvent) => void): void;
 
         /**
          * Fired when handling requests for resources within a .wbn file.
          * Note: this will only be fired for resources that are requested by the webpage.
+         * @experimental
          */
         on(event: 'subresourceWebBundleInnerResponseParsed', listener: (params: Protocol.Network.SubresourceWebBundleInnerResponseParsedEvent) => void): void;
 
         /**
          * Fired when request for resources within a .wbn file failed.
+         * @experimental
          */
         on(event: 'subresourceWebBundleInnerResponseError', listener: (params: Protocol.Network.SubresourceWebBundleInnerResponseErrorEvent) => void): void;
 
         /**
          * Is sent whenever a new report is added.
          * And after 'enableReportingApi' for all existing reports.
+         * @experimental
          */
         on(event: 'reportingApiReportAdded', listener: (params: Protocol.Network.ReportingApiReportAddedEvent) => void): void;
 
+        /**
+         * @experimental
+         */
         on(event: 'reportingApiReportUpdated', listener: (params: Protocol.Network.ReportingApiReportUpdatedEvent) => void): void;
 
+        /**
+         * @experimental
+         */
         on(event: 'reportingApiEndpointsChangedForOrigin', listener: (params: Protocol.Network.ReportingApiEndpointsChangedForOriginEvent) => void): void;
 
     }
@@ -2916,6 +3135,7 @@ export namespace ProtocolProxyApi {
          * Deprecated: Doesn't work reliably and cannot be fixed due to process
          * separation (the owner node might be in a different process). Determine
          * the owner node in the client and use highlightNode.
+         * @deprecated
          */
         highlightFrame(params: Protocol.Overlay.HighlightFrameRequest): Promise<void>;
 
@@ -2992,11 +3212,13 @@ export namespace ProtocolProxyApi {
 
         /**
          * Deprecated, no longer has any effect.
+         * @deprecated
          */
         setShowHitTestBorders(params: Protocol.Overlay.SetShowHitTestBordersRequest): Promise<void>;
 
         /**
          * Deprecated, no longer has any effect.
+         * @deprecated
          */
         setShowWebVitals(params: Protocol.Overlay.SetShowWebVitalsRequest): Promise<void>;
 
@@ -3046,6 +3268,8 @@ export namespace ProtocolProxyApi {
     export interface PageApi {
         /**
          * Deprecated, please use addScriptToEvaluateOnNewDocument instead.
+         * @deprecated
+         * @experimental
          */
         addScriptToEvaluateOnLoad(params: Protocol.Page.AddScriptToEvaluateOnLoadRequest): Promise<Protocol.Page.AddScriptToEvaluateOnLoadResponse>;
 
@@ -3067,21 +3291,27 @@ export namespace ProtocolProxyApi {
         /**
          * Returns a snapshot of the page as a string. For MHTML format, the serialization includes
          * iframes, shadow DOM, external resources, and element-inline styles.
+         * @experimental
          */
         captureSnapshot(params: Protocol.Page.CaptureSnapshotRequest): Promise<Protocol.Page.CaptureSnapshotResponse>;
 
         /**
          * Clears the overridden device metrics.
+         * @deprecated
+         * @experimental
          */
         clearDeviceMetricsOverride(): Promise<void>;
 
         /**
          * Clears the overridden Device Orientation.
+         * @deprecated
+         * @experimental
          */
         clearDeviceOrientationOverride(): Promise<void>;
 
         /**
          * Clears the overridden Geolocation Position and Error.
+         * @deprecated
          */
         clearGeolocationOverride(): Promise<void>;
 
@@ -3092,6 +3322,8 @@ export namespace ProtocolProxyApi {
 
         /**
          * Deletes browser cookie with given name, domain and path.
+         * @deprecated
+         * @experimental
          */
         deleteCookie(params: Protocol.Page.DeleteCookieRequest): Promise<void>;
 
@@ -3114,19 +3346,28 @@ export namespace ProtocolProxyApi {
          */
         getAppManifest(params: Protocol.Page.GetAppManifestRequest): Promise<Protocol.Page.GetAppManifestResponse>;
 
+        /**
+         * @experimental
+         */
         getInstallabilityErrors(): Promise<Protocol.Page.GetInstallabilityErrorsResponse>;
 
         /**
          * Deprecated because it's not guaranteed that the returned icon is in fact the one used for PWA installation.
+         * @deprecated
+         * @experimental
          */
         getManifestIcons(): Promise<Protocol.Page.GetManifestIconsResponse>;
 
         /**
          * Returns the unique (PWA) app id.
          * Only returns values if the feature flag 'WebAppEnableManifestId' is enabled
+         * @experimental
          */
         getAppId(): Promise<Protocol.Page.GetAppIdResponse>;
 
+        /**
+         * @experimental
+         */
         getAdScriptAncestry(params: Protocol.Page.GetAdScriptAncestryRequest): Promise<Protocol.Page.GetAdScriptAncestryResponse>;
 
         /**
@@ -3151,11 +3392,13 @@ export namespace ProtocolProxyApi {
 
         /**
          * Returns content of the given resource.
+         * @experimental
          */
         getResourceContent(params: Protocol.Page.GetResourceContentRequest): Promise<Protocol.Page.GetResourceContentResponse>;
 
         /**
          * Returns present frame / resource tree structure.
+         * @experimental
          */
         getResourceTree(): Promise<Protocol.Page.GetResourceTreeResponse>;
 
@@ -3186,6 +3429,8 @@ export namespace ProtocolProxyApi {
 
         /**
          * Deprecated, please use removeScriptToEvaluateOnNewDocument instead.
+         * @deprecated
+         * @experimental
          */
         removeScriptToEvaluateOnLoad(params: Protocol.Page.RemoveScriptToEvaluateOnLoadRequest): Promise<void>;
 
@@ -3196,16 +3441,19 @@ export namespace ProtocolProxyApi {
 
         /**
          * Acknowledges that a screencast frame has been received by the frontend.
+         * @experimental
          */
         screencastFrameAck(params: Protocol.Page.ScreencastFrameAckRequest): Promise<void>;
 
         /**
          * Searches for given string in resource content.
+         * @experimental
          */
         searchInResource(params: Protocol.Page.SearchInResourceRequest): Promise<Protocol.Page.SearchInResourceResponse>;
 
         /**
          * Enable Chrome's experimental ad filter on all sites.
+         * @experimental
          */
         setAdBlockingEnabled(params: Protocol.Page.SetAdBlockingEnabledRequest): Promise<void>;
 
@@ -3216,11 +3464,13 @@ export namespace ProtocolProxyApi {
 
         /**
          * Get Permissions Policy state on given frame.
+         * @experimental
          */
         getPermissionsPolicyState(params: Protocol.Page.GetPermissionsPolicyStateRequest): Promise<Protocol.Page.GetPermissionsPolicyStateResponse>;
 
         /**
          * Get Origin Trials on given frame.
+         * @experimental
          */
         getOriginTrials(params: Protocol.Page.GetOriginTrialsRequest): Promise<Protocol.Page.GetOriginTrialsResponse>;
 
@@ -3228,21 +3478,27 @@ export namespace ProtocolProxyApi {
          * Overrides the values of device screen dimensions (window.screen.width, window.screen.height,
          * window.innerWidth, window.innerHeight, and "device-width"/"device-height"-related CSS media
          * query results).
+         * @deprecated
+         * @experimental
          */
         setDeviceMetricsOverride(params: Protocol.Page.SetDeviceMetricsOverrideRequest): Promise<void>;
 
         /**
          * Overrides the Device Orientation.
+         * @deprecated
+         * @experimental
          */
         setDeviceOrientationOverride(params: Protocol.Page.SetDeviceOrientationOverrideRequest): Promise<void>;
 
         /**
          * Set generic font families.
+         * @experimental
          */
         setFontFamilies(params: Protocol.Page.SetFontFamiliesRequest): Promise<void>;
 
         /**
          * Set default font sizes.
+         * @experimental
          */
         setFontSizes(params: Protocol.Page.SetFontSizesRequest): Promise<void>;
 
@@ -3253,12 +3509,15 @@ export namespace ProtocolProxyApi {
 
         /**
          * Set the behavior when downloading a file.
+         * @deprecated
+         * @experimental
          */
         setDownloadBehavior(params: Protocol.Page.SetDownloadBehaviorRequest): Promise<void>;
 
         /**
          * Overrides the Geolocation Position or Error. Omitting any of the parameters emulates position
          * unavailable.
+         * @deprecated
          */
         setGeolocationOverride(params: Protocol.Page.SetGeolocationOverrideRequest): Promise<void>;
 
@@ -3269,11 +3528,14 @@ export namespace ProtocolProxyApi {
 
         /**
          * Toggles mouse event-based touch event emulation.
+         * @deprecated
+         * @experimental
          */
         setTouchEmulationEnabled(params: Protocol.Page.SetTouchEmulationEnabledRequest): Promise<void>;
 
         /**
          * Starts sending each frame using the `screencastFrame` event.
+         * @experimental
          */
         startScreencast(params: Protocol.Page.StartScreencastRequest): Promise<void>;
 
@@ -3284,6 +3546,7 @@ export namespace ProtocolProxyApi {
 
         /**
          * Crashes renderer on the IO thread, generates minidumps.
+         * @experimental
          */
         crash(): Promise<void>;
 
@@ -3296,11 +3559,13 @@ export namespace ProtocolProxyApi {
          * Tries to update the web lifecycle state of the page.
          * It will transition the page to the given state according to:
          * https://github.com/WICG/web-lifecycle/
+         * @experimental
          */
         setWebLifecycleState(params: Protocol.Page.SetWebLifecycleStateRequest): Promise<void>;
 
         /**
          * Stops sending each frame in the `screencastFrame`.
+         * @experimental
          */
         stopScreencast(): Promise<void>;
 
@@ -3311,39 +3576,46 @@ export namespace ProtocolProxyApi {
          * When script with a matching URL is encountered, the cache is optionally
          * produced upon backend discretion, based on internal heuristics.
          * See also: `Page.compilationCacheProduced`.
+         * @experimental
          */
         produceCompilationCache(params: Protocol.Page.ProduceCompilationCacheRequest): Promise<void>;
 
         /**
          * Seeds compilation cache for given url. Compilation cache does not survive
          * cross-process navigation.
+         * @experimental
          */
         addCompilationCache(params: Protocol.Page.AddCompilationCacheRequest): Promise<void>;
 
         /**
          * Clears seeded compilation cache.
+         * @experimental
          */
         clearCompilationCache(): Promise<void>;
 
         /**
          * Sets the Secure Payment Confirmation transaction mode.
          * https://w3c.github.io/secure-payment-confirmation/#sctn-automation-set-spc-transaction-mode
+         * @experimental
          */
         setSPCTransactionMode(params: Protocol.Page.SetSPCTransactionModeRequest): Promise<void>;
 
         /**
          * Extensions for Custom Handlers API:
          * https://html.spec.whatwg.org/multipage/system-state.html#rph-automation
+         * @experimental
          */
         setRPHRegistrationMode(params: Protocol.Page.SetRPHRegistrationModeRequest): Promise<void>;
 
         /**
          * Generates a report for testing.
+         * @experimental
          */
         generateTestReport(params: Protocol.Page.GenerateTestReportRequest): Promise<void>;
 
         /**
          * Pauses page execution. Can be resumed using generic Runtime.runIfWaitingForDebugger.
+         * @experimental
          */
         waitForDebugger(): Promise<void>;
 
@@ -3362,6 +3634,7 @@ export namespace ProtocolProxyApi {
          * for more details.
          * 
          * TODO(https://crbug.com/1440085): Remove this once Puppeteer supports tab targets.
+         * @experimental
          */
         setPrerenderingAllowed(params: Protocol.Page.SetPrerenderingAllowedRequest): Promise<void>;
 
@@ -3379,6 +3652,7 @@ export namespace ProtocolProxyApi {
 
         /**
          * Fired when frame no longer has a scheduled navigation.
+         * @deprecated
          */
         on(event: 'frameClearedScheduledNavigation', listener: (params: Protocol.Page.FrameClearedScheduledNavigationEvent) => void): void;
 
@@ -3390,6 +3664,7 @@ export namespace ProtocolProxyApi {
         /**
          * Fired before frame subtree is detached. Emitted before any frame of the
          * subtree is actually detached.
+         * @experimental
          */
         on(event: 'frameSubtreeWillBeDetached', listener: (params: Protocol.Page.FrameSubtreeWillBeDetachedEvent) => void): void;
 
@@ -3400,9 +3675,13 @@ export namespace ProtocolProxyApi {
 
         /**
          * Fired when opening document to write to.
+         * @experimental
          */
         on(event: 'documentOpened', listener: (params: Protocol.Page.DocumentOpenedEvent) => void): void;
 
+        /**
+         * @experimental
+         */
         on(event: 'frameResized', listener: () => void): void;
 
         /**
@@ -3413,39 +3692,48 @@ export namespace ProtocolProxyApi {
          * can be fired for a single navigation, for example, when a same-document
          * navigation becomes a cross-document navigation (such as in the case of a
          * frameset).
+         * @experimental
          */
         on(event: 'frameStartedNavigating', listener: (params: Protocol.Page.FrameStartedNavigatingEvent) => void): void;
 
         /**
          * Fired when a renderer-initiated navigation is requested.
          * Navigation may still be cancelled after the event is issued.
+         * @experimental
          */
         on(event: 'frameRequestedNavigation', listener: (params: Protocol.Page.FrameRequestedNavigationEvent) => void): void;
 
         /**
          * Fired when frame schedules a potential navigation.
+         * @deprecated
          */
         on(event: 'frameScheduledNavigation', listener: (params: Protocol.Page.FrameScheduledNavigationEvent) => void): void;
 
         /**
          * Fired when frame has started loading.
+         * @experimental
          */
         on(event: 'frameStartedLoading', listener: (params: Protocol.Page.FrameStartedLoadingEvent) => void): void;
 
         /**
          * Fired when frame has stopped loading.
+         * @experimental
          */
         on(event: 'frameStoppedLoading', listener: (params: Protocol.Page.FrameStoppedLoadingEvent) => void): void;
 
         /**
          * Fired when page is about to start a download.
          * Deprecated. Use Browser.downloadWillBegin instead.
+         * @deprecated
+         * @experimental
          */
         on(event: 'downloadWillBegin', listener: (params: Protocol.Page.DownloadWillBeginEvent) => void): void;
 
         /**
          * Fired when download makes progress. Last call has |done| == true.
          * Deprecated. Use Browser.downloadProgress instead.
+         * @deprecated
+         * @experimental
          */
         on(event: 'downloadProgress', listener: (params: Protocol.Page.DownloadProgressEvent) => void): void;
 
@@ -3482,6 +3770,7 @@ export namespace ProtocolProxyApi {
          * not assume any ordering with the Page.frameNavigated event. This event is fired only for
          * main-frame history navigation where the document changes (non-same-document navigations),
          * when bfcache navigation fails.
+         * @experimental
          */
         on(event: 'backForwardCacheNotUsed', listener: (params: Protocol.Page.BackForwardCacheNotUsedEvent) => void): void;
 
@@ -3489,16 +3778,19 @@ export namespace ProtocolProxyApi {
 
         /**
          * Fired when same-document navigation happens, e.g. due to history API usage or anchor navigation.
+         * @experimental
          */
         on(event: 'navigatedWithinDocument', listener: (params: Protocol.Page.NavigatedWithinDocumentEvent) => void): void;
 
         /**
          * Compressed image data requested by the `startScreencast`.
+         * @experimental
          */
         on(event: 'screencastFrame', listener: (params: Protocol.Page.ScreencastFrameEvent) => void): void;
 
         /**
          * Fired when the page with currently enabled screencast was shown or hidden `.
+         * @experimental
          */
         on(event: 'screencastVisibilityChanged', listener: (params: Protocol.Page.ScreencastVisibilityChangedEvent) => void): void;
 
@@ -3511,6 +3803,7 @@ export namespace ProtocolProxyApi {
         /**
          * Issued for every compilation cache generated. Is only available
          * if Page.setGenerateCompilationCache is enabled.
+         * @experimental
          */
         on(event: 'compilationCacheProduced', listener: (params: Protocol.Page.CompilationCacheProducedEvent) => void): void;
 
@@ -3531,6 +3824,8 @@ export namespace ProtocolProxyApi {
          * Sets time domain to use for collecting and reporting duration metrics.
          * Note that this must be called before enabling metrics collection. Calling
          * this method while metrics collection is enabled returns an error.
+         * @deprecated
+         * @experimental
          */
         setTimeDomain(params: Protocol.Performance.SetTimeDomainRequest): Promise<void>;
 
@@ -3578,12 +3873,14 @@ export namespace ProtocolProxyApi {
 
         /**
          * Handles a certificate error that fired a certificateError event.
+         * @deprecated
          */
         handleCertificateError(params: Protocol.Security.HandleCertificateErrorRequest): Promise<void>;
 
         /**
          * Enable/disable overriding certificate errors. If enabled, all certificate error events need to
          * be handled by the DevTools client and should be answered with `handleCertificateError` commands.
+         * @deprecated
          */
         setOverrideCertificateErrors(params: Protocol.Security.SetOverrideCertificateErrorsRequest): Promise<void>;
 
@@ -3592,16 +3889,19 @@ export namespace ProtocolProxyApi {
          * handled with the `handleCertificateError` command. Note: this event does not fire if the
          * certificate error has been allowed internally. Only one client per target should override
          * certificate errors at the same time.
+         * @deprecated
          */
         on(event: 'certificateError', listener: (params: Protocol.Security.CertificateErrorEvent) => void): void;
 
         /**
          * The security state of the page changed.
+         * @experimental
          */
         on(event: 'visibleSecurityStateChanged', listener: (params: Protocol.Security.VisibleSecurityStateChangedEvent) => void): void;
 
         /**
          * The security state of the page changed. No longer being sent.
+         * @deprecated
          */
         on(event: 'securityStateChanged', listener: (params: Protocol.Security.SecurityStateChangedEvent) => void): void;
 
@@ -3678,6 +3978,7 @@ export namespace ProtocolProxyApi {
 
         /**
          * Override quota for the specified origin
+         * @experimental
          */
         overrideQuotaForOrigin(params: Protocol.Storage.OverrideQuotaForOriginRequest): Promise<void>;
 
@@ -3724,100 +4025,119 @@ export namespace ProtocolProxyApi {
         /**
          * Returns the number of stored Trust Tokens per issuer for the
          * current browsing context.
+         * @experimental
          */
         getTrustTokens(): Promise<Protocol.Storage.GetTrustTokensResponse>;
 
         /**
          * Removes all Trust Tokens issued by the provided issuerOrigin.
          * Leaves other stored data, including the issuer's Redemption Records, intact.
+         * @experimental
          */
         clearTrustTokens(params: Protocol.Storage.ClearTrustTokensRequest): Promise<Protocol.Storage.ClearTrustTokensResponse>;
 
         /**
          * Gets details for a named interest group.
+         * @experimental
          */
         getInterestGroupDetails(params: Protocol.Storage.GetInterestGroupDetailsRequest): Promise<Protocol.Storage.GetInterestGroupDetailsResponse>;
 
         /**
          * Enables/Disables issuing of interestGroupAccessed events.
+         * @experimental
          */
         setInterestGroupTracking(params: Protocol.Storage.SetInterestGroupTrackingRequest): Promise<void>;
 
         /**
          * Enables/Disables issuing of interestGroupAuctionEventOccurred and
          * interestGroupAuctionNetworkRequestCreated.
+         * @experimental
          */
         setInterestGroupAuctionTracking(params: Protocol.Storage.SetInterestGroupAuctionTrackingRequest): Promise<void>;
 
         /**
          * Gets metadata for an origin's shared storage.
+         * @experimental
          */
         getSharedStorageMetadata(params: Protocol.Storage.GetSharedStorageMetadataRequest): Promise<Protocol.Storage.GetSharedStorageMetadataResponse>;
 
         /**
          * Gets the entries in an given origin's shared storage.
+         * @experimental
          */
         getSharedStorageEntries(params: Protocol.Storage.GetSharedStorageEntriesRequest): Promise<Protocol.Storage.GetSharedStorageEntriesResponse>;
 
         /**
          * Sets entry with `key` and `value` for a given origin's shared storage.
+         * @experimental
          */
         setSharedStorageEntry(params: Protocol.Storage.SetSharedStorageEntryRequest): Promise<void>;
 
         /**
          * Deletes entry for `key` (if it exists) for a given origin's shared storage.
+         * @experimental
          */
         deleteSharedStorageEntry(params: Protocol.Storage.DeleteSharedStorageEntryRequest): Promise<void>;
 
         /**
          * Clears all entries for a given origin's shared storage.
+         * @experimental
          */
         clearSharedStorageEntries(params: Protocol.Storage.ClearSharedStorageEntriesRequest): Promise<void>;
 
         /**
          * Resets the budget for `ownerOrigin` by clearing all budget withdrawals.
+         * @experimental
          */
         resetSharedStorageBudget(params: Protocol.Storage.ResetSharedStorageBudgetRequest): Promise<void>;
 
         /**
          * Enables/disables issuing of sharedStorageAccessed events.
+         * @experimental
          */
         setSharedStorageTracking(params: Protocol.Storage.SetSharedStorageTrackingRequest): Promise<void>;
 
         /**
          * Set tracking for a storage key's buckets.
+         * @experimental
          */
         setStorageBucketTracking(params: Protocol.Storage.SetStorageBucketTrackingRequest): Promise<void>;
 
         /**
          * Deletes the Storage Bucket with the given storage key and bucket name.
+         * @experimental
          */
         deleteStorageBucket(params: Protocol.Storage.DeleteStorageBucketRequest): Promise<void>;
 
         /**
          * Deletes state for sites identified as potential bounce trackers, immediately.
+         * @experimental
          */
         runBounceTrackingMitigations(): Promise<Protocol.Storage.RunBounceTrackingMitigationsResponse>;
 
         /**
          * https://wicg.github.io/attribution-reporting-api/
+         * @experimental
          */
         setAttributionReportingLocalTestingMode(params: Protocol.Storage.SetAttributionReportingLocalTestingModeRequest): Promise<void>;
 
         /**
          * Enables/disables issuing of Attribution Reporting events.
+         * @experimental
          */
         setAttributionReportingTracking(params: Protocol.Storage.SetAttributionReportingTrackingRequest): Promise<void>;
 
         /**
          * Sends all pending Attribution Reports immediately, regardless of their
          * scheduled report time.
+         * @experimental
          */
         sendPendingAttributionReports(): Promise<Protocol.Storage.SendPendingAttributionReportsResponse>;
 
         /**
          * Returns the effective Related Website Sets in use by this profile for the browser
          * session. The effective Related Website Sets will not change during a browser session.
+         * @experimental
          */
         getRelatedWebsiteSets(): Promise<Protocol.Storage.GetRelatedWebsiteSetsResponse>;
 
@@ -3825,6 +4145,7 @@ export namespace ProtocolProxyApi {
          * Returns the list of URLs from a page and its embedded resources that match
          * existing grace period URL pattern rules.
          * https://developers.google.com/privacy-sandbox/cookies/temporary-exceptions/grace-period
+         * @experimental
          */
         getAffectedUrlsForThirdPartyCookieMetadata(params: Protocol.Storage.GetAffectedUrlsForThirdPartyCookieMetadataRequest): Promise<Protocol.Storage.GetAffectedUrlsForThirdPartyCookieMetadataResponse>;
 
@@ -3886,12 +4207,24 @@ export namespace ProtocolProxyApi {
 
         on(event: 'storageBucketDeleted', listener: (params: Protocol.Storage.StorageBucketDeletedEvent) => void): void;
 
+        /**
+         * @experimental
+         */
         on(event: 'attributionReportingSourceRegistered', listener: (params: Protocol.Storage.AttributionReportingSourceRegisteredEvent) => void): void;
 
+        /**
+         * @experimental
+         */
         on(event: 'attributionReportingTriggerRegistered', listener: (params: Protocol.Storage.AttributionReportingTriggerRegisteredEvent) => void): void;
 
+        /**
+         * @experimental
+         */
         on(event: 'attributionReportingReportSent', listener: (params: Protocol.Storage.AttributionReportingReportSentEvent) => void): void;
 
+        /**
+         * @experimental
+         */
         on(event: 'attributionReportingVerboseDebugReportSent', listener: (params: Protocol.Storage.AttributionReportingVerboseDebugReportSentEvent) => void): void;
 
     }
@@ -3927,6 +4260,7 @@ export namespace ProtocolProxyApi {
 
         /**
          * Attaches to the browser target, only uses flat sessionId mode.
+         * @experimental
          */
         attachToBrowserTarget(): Promise<Protocol.Target.AttachToBrowserTargetResponse>;
 
@@ -3944,6 +4278,7 @@ export namespace ProtocolProxyApi {
          * The object has the following API:
          * - `binding.send(json)` - a method to send messages over the remote debugging protocol
          * - `binding.onmessage = json => handleMessage(json)` - a callback that will be called for the protocol notifications and command responses.
+         * @experimental
          */
         exposeDevToolsProtocol(params: Protocol.Target.ExposeDevToolsProtocolRequest): Promise<void>;
 
@@ -3976,6 +4311,7 @@ export namespace ProtocolProxyApi {
 
         /**
          * Returns information about a target.
+         * @experimental
          */
         getTargetInfo(params: Protocol.Target.GetTargetInfoRequest): Promise<Protocol.Target.GetTargetInfoResponse>;
 
@@ -3988,6 +4324,7 @@ export namespace ProtocolProxyApi {
          * Sends protocol message over session with given id.
          * Consider using flat mode instead; see commands attachToTarget, setAutoAttach,
          * and crbug.com/991325.
+         * @deprecated
          */
         sendMessageToTarget(params: Protocol.Target.SendMessageToTargetRequest): Promise<void>;
 
@@ -4009,6 +4346,7 @@ export namespace ProtocolProxyApi {
          * through `attachedToTarget`. The specified target is also auto-attached.
          * This cancels the effect of any previous `setAutoAttach` and is also cancelled by subsequent
          * `setAutoAttach`. Only available at the Browser target.
+         * @experimental
          */
         autoAttachRelated(params: Protocol.Target.AutoAttachRelatedRequest): Promise<void>;
 
@@ -4021,17 +4359,20 @@ export namespace ProtocolProxyApi {
         /**
          * Enables target discovery for the specified locations, when `setDiscoverTargets` was set to
          * `true`.
+         * @experimental
          */
         setRemoteLocations(params: Protocol.Target.SetRemoteLocationsRequest): Promise<void>;
 
         /**
          * Issued when attached to target because of auto-attach or `attachToTarget` command.
+         * @experimental
          */
         on(event: 'attachedToTarget', listener: (params: Protocol.Target.AttachedToTargetEvent) => void): void;
 
         /**
          * Issued when detached from target for any reason (including `detachFromTarget` command). Can be
          * issued multiple times per target if multiple sessions have been attached to it.
+         * @experimental
          */
         on(event: 'detachedFromTarget', listener: (params: Protocol.Target.DetachedFromTargetEvent) => void): void;
 
@@ -4090,16 +4431,19 @@ export namespace ProtocolProxyApi {
 
         /**
          * Gets supported tracing categories.
+         * @experimental
          */
         getCategories(): Promise<Protocol.Tracing.GetCategoriesResponse>;
 
         /**
          * Record a clock sync marker in the trace.
+         * @experimental
          */
         recordClockSyncMarker(params: Protocol.Tracing.RecordClockSyncMarkerRequest): Promise<void>;
 
         /**
          * Request a global memory dump.
+         * @experimental
          */
         requestMemoryDump(params: Protocol.Tracing.RequestMemoryDumpRequest): Promise<Protocol.Tracing.RequestMemoryDumpResponse>;
 
@@ -4108,11 +4452,15 @@ export namespace ProtocolProxyApi {
          */
         start(params: Protocol.Tracing.StartRequest): Promise<void>;
 
+        /**
+         * @experimental
+         */
         on(event: 'bufferUsage', listener: (params: Protocol.Tracing.BufferUsageEvent) => void): void;
 
         /**
          * Contains a bucket of collected trace events. When tracing is stopped collected events will be
          * sent as a sequence of dataCollected events followed by tracingComplete event.
+         * @experimental
          */
         on(event: 'dataCollected', listener: (params: Protocol.Tracing.DataCollectedEvent) => void): void;
 
@@ -4160,6 +4508,7 @@ export namespace ProtocolProxyApi {
          * Continues loading of the paused response, optionally modifying the
          * response headers. If either responseCode or headers are modified, all of them
          * must be present.
+         * @experimental
          */
         continueResponse(params: Protocol.Fetch.ContinueResponseRequest): Promise<void>;
 

--- a/types/protocol-tests-proxy-api.d.ts
+++ b/types/protocol-tests-proxy-api.d.ts
@@ -178,6 +178,9 @@ export namespace ProtocolTestsProxyApi {
          */
         getScriptSource(params: Protocol.Debugger.GetScriptSourceRequest): Promise<{id: number, result: Protocol.Debugger.GetScriptSourceResponse, sessionId: string}>;
 
+        /**
+         * @experimental
+         */
         disassembleWasmModule(params: Protocol.Debugger.DisassembleWasmModuleRequest): Promise<{id: number, result: Protocol.Debugger.DisassembleWasmModuleResponse, sessionId: string}>;
 
         /**
@@ -185,16 +188,19 @@ export namespace ProtocolTestsProxyApi {
          * stream. If disassembly is complete, this API will invalidate the streamId
          * and return an empty chunk. Any subsequent calls for the now invalid stream
          * will return errors.
+         * @experimental
          */
         nextWasmDisassemblyChunk(params: Protocol.Debugger.NextWasmDisassemblyChunkRequest): Promise<{id: number, result: Protocol.Debugger.NextWasmDisassemblyChunkResponse, sessionId: string}>;
 
         /**
          * This command is deprecated. Use getScriptSource instead.
+         * @deprecated
          */
         getWasmBytecode(params: Protocol.Debugger.GetWasmBytecodeRequest): Promise<{id: number, result: Protocol.Debugger.GetWasmBytecodeResponse, sessionId: string}>;
 
         /**
          * Returns stack trace with given `stackTraceId`.
+         * @experimental
          */
         getStackTrace(params: Protocol.Debugger.GetStackTraceRequest): Promise<{id: number, result: Protocol.Debugger.GetStackTraceResponse, sessionId: string}>;
 
@@ -203,6 +209,10 @@ export namespace ProtocolTestsProxyApi {
          */
         pause(): Promise<{id: number, result: void, sessionId: string}>;
 
+        /**
+         * @deprecated
+         * @experimental
+         */
         pauseOnAsyncCall(params: Protocol.Debugger.PauseOnAsyncCallRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
@@ -246,6 +256,7 @@ export namespace ProtocolTestsProxyApi {
          * Replace previous blackbox execution contexts with passed ones. Forces backend to skip
          * stepping/pausing in scripts in these execution contexts. VM will try to leave blackboxed script by
          * performing 'step in' several times, finally resorting to 'step out' if unsuccessful.
+         * @experimental
          */
         setBlackboxExecutionContexts(params: Protocol.Debugger.SetBlackboxExecutionContextsRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -253,6 +264,7 @@ export namespace ProtocolTestsProxyApi {
          * Replace previous blackbox patterns with passed ones. Forces backend to skip stepping/pausing in
          * scripts with url matching one of the patterns. VM will try to leave blackboxed script by
          * performing 'step in' several times, finally resorting to 'step out' if unsuccessful.
+         * @experimental
          */
         setBlackboxPatterns(params: Protocol.Debugger.SetBlackboxPatternsRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -261,6 +273,7 @@ export namespace ProtocolTestsProxyApi {
          * scripts by performing 'step in' several times, finally resorting to 'step out' if unsuccessful.
          * Positions array contains positions where blackbox state is changed. First interval isn't
          * blackboxed. Array should be sorted.
+         * @experimental
          */
         setBlackboxedRanges(params: Protocol.Debugger.SetBlackboxedRangesRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -286,6 +299,7 @@ export namespace ProtocolTestsProxyApi {
          * Sets JavaScript breakpoint before each call to the given function.
          * If another function was created from the same source as a given one,
          * calling it will also trigger the breakpoint.
+         * @experimental
          */
         setBreakpointOnFunctionCall(params: Protocol.Debugger.SetBreakpointOnFunctionCallRequest): Promise<{id: number, result: Protocol.Debugger.SetBreakpointOnFunctionCallResponse, sessionId: string}>;
 
@@ -302,6 +316,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Changes return value in top frame. Available only at return break position.
+         * @experimental
          */
         setReturnValue(params: Protocol.Debugger.SetReturnValueRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -345,6 +360,7 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Fired when breakpoint is resolved to an actual script and location.
          * Deprecated in favor of `resolvedBreakpoints` in the `scriptParsed` event.
+         * @deprecated
          */
         onBreakpointResolved(listener: (event: { params: Protocol.Debugger.BreakpointResolvedEvent }) => void): void;
         offBreakpointResolved(listener: (event: { params: Protocol.Debugger.BreakpointResolvedEvent }) => void): void;
@@ -495,6 +511,7 @@ export namespace ProtocolTestsProxyApi {
          * `takePreciseCoverage` for the current isolate. May only be sent if precise code
          * coverage has been started. This event can be trigged by the embedder to, for example,
          * trigger collection of coverage data immediately at a certain point in time.
+         * @experimental
          */
         onPreciseCoverageDeltaUpdate(listener: (event: { params: Protocol.Profiler.PreciseCoverageDeltaUpdateEvent }) => void): void;
         offPreciseCoverageDeltaUpdate(listener: (event: { params: Protocol.Profiler.PreciseCoverageDeltaUpdateEvent }) => void): void;
@@ -543,12 +560,14 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Returns the isolate id.
+         * @experimental
          */
         getIsolateId(): Promise<{id: number, result: Protocol.Runtime.GetIsolateIdResponse, sessionId: string}>;
 
         /**
          * Returns the JavaScript heap usage.
          * It is the total usage of the corresponding isolate not scoped to a particular Runtime.
+         * @experimental
          */
         getHeapUsage(): Promise<{id: number, result: Protocol.Runtime.GetHeapUsageResponse, sessionId: string}>;
 
@@ -590,13 +609,20 @@ export namespace ProtocolTestsProxyApi {
          */
         setAsyncCallStackDepth(params: Protocol.Runtime.SetAsyncCallStackDepthRequest): Promise<{id: number, result: void, sessionId: string}>;
 
+        /**
+         * @experimental
+         */
         setCustomObjectFormatterEnabled(params: Protocol.Runtime.SetCustomObjectFormatterEnabledRequest): Promise<{id: number, result: void, sessionId: string}>;
 
+        /**
+         * @experimental
+         */
         setMaxCallStackSizeToCapture(params: Protocol.Runtime.SetMaxCallStackSizeToCaptureRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Terminate current or next JavaScript execution.
          * Will cancel the termination when the outer-most script execution ends.
+         * @experimental
          */
         terminateExecution(): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -622,11 +648,13 @@ export namespace ProtocolTestsProxyApi {
          * Note that the stackTrace portion of the resulting exceptionDetails will
          * only be populated if the Runtime domain was enabled at the time when the
          * Error was thrown.
+         * @experimental
          */
         getExceptionDetails(params: Protocol.Runtime.GetExceptionDetailsRequest): Promise<{id: number, result: Protocol.Runtime.GetExceptionDetailsResponse, sessionId: string}>;
 
         /**
          * Notification is issued every time when binding is called.
+         * @experimental
          */
         onBindingCalled(listener: (event: { params: Protocol.Runtime.BindingCalledEvent }) => void): void;
         offBindingCalled(listener: (event: { params: Protocol.Runtime.BindingCalledEvent }) => void): void;
@@ -706,29 +734,34 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fetches the accessibility node and partial accessibility tree for this DOM node, if it exists.
+         * @experimental
          */
         getPartialAXTree(params: Protocol.Accessibility.GetPartialAXTreeRequest): Promise<{id: number, result: Protocol.Accessibility.GetPartialAXTreeResponse, sessionId: string}>;
 
         /**
          * Fetches the entire accessibility tree for the root Document
+         * @experimental
          */
         getFullAXTree(params: Protocol.Accessibility.GetFullAXTreeRequest): Promise<{id: number, result: Protocol.Accessibility.GetFullAXTreeResponse, sessionId: string}>;
 
         /**
          * Fetches the root node.
          * Requires `enable()` to have been called previously.
+         * @experimental
          */
         getRootAXNode(params: Protocol.Accessibility.GetRootAXNodeRequest): Promise<{id: number, result: Protocol.Accessibility.GetRootAXNodeResponse, sessionId: string}>;
 
         /**
          * Fetches a node and all ancestors up to and including the root.
          * Requires `enable()` to have been called previously.
+         * @experimental
          */
         getAXNodeAndAncestors(params: Protocol.Accessibility.GetAXNodeAndAncestorsRequest): Promise<{id: number, result: Protocol.Accessibility.GetAXNodeAndAncestorsResponse, sessionId: string}>;
 
         /**
          * Fetches a particular accessibility node by AXNodeId.
          * Requires `enable()` to have been called previously.
+         * @experimental
          */
         getChildAXNodes(params: Protocol.Accessibility.GetChildAXNodesRequest): Promise<{id: number, result: Protocol.Accessibility.GetChildAXNodesResponse, sessionId: string}>;
 
@@ -738,12 +771,14 @@ export namespace ProtocolTestsProxyApi {
          * ignored for accessibility, and returns those that match the specified name and role. If no DOM
          * node is specified, or the DOM node does not exist, the command returns an error. If neither
          * `accessibleName` or `role` is specified, it returns all the accessibility nodes in the subtree.
+         * @experimental
          */
         queryAXTree(params: Protocol.Accessibility.QueryAXTreeRequest): Promise<{id: number, result: Protocol.Accessibility.QueryAXTreeResponse, sessionId: string}>;
 
         /**
          * The loadComplete event mirrors the load complete event sent by the browser to assistive
          * technology when the web page has finished loading.
+         * @experimental
          */
         onLoadComplete(listener: (event: { params: Protocol.Accessibility.LoadCompleteEvent }) => void): void;
         offLoadComplete(listener: (event: { params: Protocol.Accessibility.LoadCompleteEvent }) => void): void;
@@ -751,6 +786,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * The nodesUpdated event is sent every time a previously requested node has changed the in tree.
+         * @experimental
          */
         onNodesUpdated(listener: (event: { params: Protocol.Accessibility.NodesUpdatedEvent }) => void): void;
         offNodesUpdated(listener: (event: { params: Protocol.Accessibility.NodesUpdatedEvent }) => void): void;
@@ -988,11 +1024,13 @@ export namespace ProtocolTestsProxyApi {
     export interface BrowserApi {
         /**
          * Set permission settings for given origin.
+         * @experimental
          */
         setPermission(params: Protocol.Browser.SetPermissionRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Grant specific permissions to the given origin and reject all others.
+         * @experimental
          */
         grantPermissions(params: Protocol.Browser.GrantPermissionsRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -1003,11 +1041,13 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Set the behavior when downloading a file.
+         * @experimental
          */
         setDownloadBehavior(params: Protocol.Browser.SetDownloadBehaviorRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Cancel a download if in progress
+         * @experimental
          */
         cancelDownload(params: Protocol.Browser.CancelDownloadRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -1018,11 +1058,13 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Crashes browser on the main thread.
+         * @experimental
          */
         crash(): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Crashes GPU process.
+         * @experimental
          */
         crashGpuProcess(): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -1034,46 +1076,55 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Returns the command line switches for the browser process if, and only if
          * --enable-automation is on the commandline.
+         * @experimental
          */
         getBrowserCommandLine(): Promise<{id: number, result: Protocol.Browser.GetBrowserCommandLineResponse, sessionId: string}>;
 
         /**
          * Get Chrome histograms.
+         * @experimental
          */
         getHistograms(params: Protocol.Browser.GetHistogramsRequest): Promise<{id: number, result: Protocol.Browser.GetHistogramsResponse, sessionId: string}>;
 
         /**
          * Get a Chrome histogram by name.
+         * @experimental
          */
         getHistogram(params: Protocol.Browser.GetHistogramRequest): Promise<{id: number, result: Protocol.Browser.GetHistogramResponse, sessionId: string}>;
 
         /**
          * Get position and size of the browser window.
+         * @experimental
          */
         getWindowBounds(params: Protocol.Browser.GetWindowBoundsRequest): Promise<{id: number, result: Protocol.Browser.GetWindowBoundsResponse, sessionId: string}>;
 
         /**
          * Get the browser window that contains the devtools target.
+         * @experimental
          */
         getWindowForTarget(params: Protocol.Browser.GetWindowForTargetRequest): Promise<{id: number, result: Protocol.Browser.GetWindowForTargetResponse, sessionId: string}>;
 
         /**
          * Set position and/or size of the browser window.
+         * @experimental
          */
         setWindowBounds(params: Protocol.Browser.SetWindowBoundsRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Set size of the browser contents resizing browser window as necessary.
+         * @experimental
          */
         setContentsSize(params: Protocol.Browser.SetContentsSizeRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Set dock tile details, platform-specific.
+         * @experimental
          */
         setDockTile(params: Protocol.Browser.SetDockTileRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Invoke custom browser commands used by telemetry.
+         * @experimental
          */
         executeBrowserCommand(params: Protocol.Browser.ExecuteBrowserCommandRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -1093,6 +1144,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when page is about to start a download.
+         * @experimental
          */
         onDownloadWillBegin(listener: (event: { params: Protocol.Browser.DownloadWillBeginEvent }) => void): void;
         offDownloadWillBegin(listener: (event: { params: Protocol.Browser.DownloadWillBeginEvent }) => void): void;
@@ -1100,6 +1152,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when download makes progress. Last call has |done| == true.
+         * @experimental
          */
         onDownloadProgress(listener: (event: { params: Protocol.Browser.DownloadProgressEvent }) => void): void;
         offDownloadProgress(listener: (event: { params: Protocol.Browser.DownloadProgressEvent }) => void): void;
@@ -1163,9 +1216,13 @@ export namespace ProtocolTestsProxyApi {
          * to the provided property syntax, the value is parsed using combined
          * syntax as if null `propertyName` was provided. If the value cannot be
          * resolved even then, return the provided value without any changes.
+         * @experimental
          */
         resolveValues(params: Protocol.CSS.ResolveValuesRequest): Promise<{id: number, result: Protocol.CSS.ResolveValuesResponse, sessionId: string}>;
 
+        /**
+         * @experimental
+         */
         getLonghandProperties(params: Protocol.CSS.GetLonghandPropertiesRequest): Promise<{id: number, result: Protocol.CSS.GetLonghandPropertiesResponse, sessionId: string}>;
 
         /**
@@ -1177,6 +1234,7 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Returns the styles coming from animations & transitions
          * including the animation & transition styles coming from inheritance chain.
+         * @experimental
          */
         getAnimatedStylesForNode(params: Protocol.CSS.GetAnimatedStylesForNodeRequest): Promise<{id: number, result: Protocol.CSS.GetAnimatedStylesForNodeResponse, sessionId: string}>;
 
@@ -1187,6 +1245,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Returns the values of the default UA-defined environment variables used in env()
+         * @experimental
          */
         getEnvironmentVariables(): Promise<{id: number, result: Protocol.CSS.GetEnvironmentVariablesResponse, sessionId: string}>;
 
@@ -1211,12 +1270,14 @@ export namespace ProtocolTestsProxyApi {
          * Given a DOM element identified by nodeId, getLayersForNode returns the root
          * layer for the nearest ancestor document or shadow root. The layer root contains
          * the full layer tree for the tree scope and their ordering.
+         * @experimental
          */
         getLayersForNode(params: Protocol.CSS.GetLayersForNodeRequest): Promise<{id: number, result: Protocol.CSS.GetLayersForNodeResponse, sessionId: string}>;
 
         /**
          * Given a CSS selector text and a style sheet ID, getLocationForSelector
          * returns an array of locations of the CSS selector in the style sheet.
+         * @experimental
          */
         getLocationForSelector(params: Protocol.CSS.GetLocationForSelectorRequest): Promise<{id: number, result: Protocol.CSS.GetLocationForSelectorResponse, sessionId: string}>;
 
@@ -1227,6 +1288,7 @@ export namespace ProtocolTestsProxyApi {
          * There can only be 1 node tracked for computed style updates
          * so passing a new node id removes tracking from the previous node.
          * Pass `undefined` to disable tracking.
+         * @experimental
          */
         trackComputedStyleUpdatesForNode(params: Protocol.CSS.TrackComputedStyleUpdatesForNodeRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -1237,11 +1299,13 @@ export namespace ProtocolTestsProxyApi {
          * The changes to computed style properties are only tracked for nodes pushed to the front-end
          * by the DOM agent. If no changes to the tracked properties occur after the node has been pushed
          * to the front-end, no updates will be issued for the node.
+         * @experimental
          */
         trackComputedStyleUpdates(params: Protocol.CSS.TrackComputedStyleUpdatesRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Polls the next batch of computed style updates.
+         * @experimental
          */
         takeComputedStyleUpdates(): Promise<{id: number, result: Protocol.CSS.TakeComputedStyleUpdatesResponse, sessionId: string}>;
 
@@ -1268,16 +1332,19 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Modifies the expression of a container query.
+         * @experimental
          */
         setContainerQueryText(params: Protocol.CSS.SetContainerQueryTextRequest): Promise<{id: number, result: Protocol.CSS.SetContainerQueryTextResponse, sessionId: string}>;
 
         /**
          * Modifies the expression of a supports at-rule.
+         * @experimental
          */
         setSupportsText(params: Protocol.CSS.SetSupportsTextRequest): Promise<{id: number, result: Protocol.CSS.SetSupportsTextResponse, sessionId: string}>;
 
         /**
          * Modifies the expression of a scope at-rule.
+         * @experimental
          */
         setScopeText(params: Protocol.CSS.SetScopeTextRequest): Promise<{id: number, result: Protocol.CSS.SetScopeTextResponse, sessionId: string}>;
 
@@ -1315,6 +1382,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Enables/disables rendering of local CSS fonts (enabled by default).
+         * @experimental
          */
         setLocalFontsEnabled(params: Protocol.CSS.SetLocalFontsEnabledRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -1355,6 +1423,9 @@ export namespace ProtocolTestsProxyApi {
         offStyleSheetRemoved(listener: (event: { params: Protocol.CSS.StyleSheetRemovedEvent }) => void): void;
         onceStyleSheetRemoved(eventMatcher?: (event: { params: Protocol.CSS.StyleSheetRemovedEvent }) => boolean): Promise<{ params: Protocol.CSS.StyleSheetRemovedEvent }>;
 
+        /**
+         * @experimental
+         */
         onComputedStyleUpdated(listener: (event: { params: Protocol.CSS.ComputedStyleUpdatedEvent }) => void): void;
         offComputedStyleUpdated(listener: (event: { params: Protocol.CSS.ComputedStyleUpdatedEvent }) => void): void;
         onceComputedStyleUpdated(eventMatcher?: (event: { params: Protocol.CSS.ComputedStyleUpdatedEvent }) => boolean): Promise<{ params: Protocol.CSS.ComputedStyleUpdatedEvent }>;
@@ -1446,12 +1517,14 @@ export namespace ProtocolTestsProxyApi {
     export interface DOMApi {
         /**
          * Collects class names for the node with given id and all of it's child nodes.
+         * @experimental
          */
         collectClassNamesFromSubtree(params: Protocol.DOM.CollectClassNamesFromSubtreeRequest): Promise<{id: number, result: Protocol.DOM.CollectClassNamesFromSubtreeResponse, sessionId: string}>;
 
         /**
          * Creates a deep copy of the specified node and places it into the target container before the
          * given anchor.
+         * @experimental
          */
         copyTo(params: Protocol.DOM.CopyToRequest): Promise<{id: number, result: Protocol.DOM.CopyToResponse, sessionId: string}>;
 
@@ -1476,6 +1549,7 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Discards search results from the session with the given id. `getSearchResults` should no longer
          * be called for that search.
+         * @experimental
          */
         discardSearchResults(params: Protocol.DOM.DiscardSearchResultsRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -1502,6 +1576,7 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Returns quads that describe node position on the page. This method
          * might return multiple quads for inline nodes.
+         * @experimental
          */
         getContentQuads(params: Protocol.DOM.GetContentQuadsRequest): Promise<{id: number, result: Protocol.DOM.GetContentQuadsResponse, sessionId: string}>;
 
@@ -1515,11 +1590,13 @@ export namespace ProtocolTestsProxyApi {
          * Returns the root DOM node (and optionally the subtree) to the caller.
          * Deprecated, as it is not designed to work well with the rest of the DOM agent.
          * Use DOMSnapshot.captureSnapshot instead.
+         * @deprecated
          */
         getFlattenedDocument(params: Protocol.DOM.GetFlattenedDocumentRequest): Promise<{id: number, result: Protocol.DOM.GetFlattenedDocumentResponse, sessionId: string}>;
 
         /**
          * Finds nodes with a given computed style in a subtree.
+         * @experimental
          */
         getNodesForSubtreeByStyle(params: Protocol.DOM.GetNodesForSubtreeByStyleRequest): Promise<{id: number, result: Protocol.DOM.GetNodesForSubtreeByStyleResponse, sessionId: string}>;
 
@@ -1536,12 +1613,14 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Returns the id of the nearest ancestor that is a relayout boundary.
+         * @experimental
          */
         getRelayoutBoundary(params: Protocol.DOM.GetRelayoutBoundaryRequest): Promise<{id: number, result: Protocol.DOM.GetRelayoutBoundaryResponse, sessionId: string}>;
 
         /**
          * Returns search results from given `fromIndex` to given `toIndex` from the search with the given
          * identifier.
+         * @experimental
          */
         getSearchResults(params: Protocol.DOM.GetSearchResultsRequest): Promise<{id: number, result: Protocol.DOM.GetSearchResultsResponse, sessionId: string}>;
 
@@ -1562,6 +1641,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Marks last undoable state.
+         * @experimental
          */
         markUndoableState(): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -1573,16 +1653,19 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Searches for a given string in the DOM tree. Use `getSearchResults` to access search results or
          * `cancelSearch` to end this search session.
+         * @experimental
          */
         performSearch(params: Protocol.DOM.PerformSearchRequest): Promise<{id: number, result: Protocol.DOM.PerformSearchResponse, sessionId: string}>;
 
         /**
          * Requests that the node is sent to the caller given its path. // FIXME, use XPath
+         * @experimental
          */
         pushNodeByPathToFrontend(params: Protocol.DOM.PushNodeByPathToFrontendRequest): Promise<{id: number, result: Protocol.DOM.PushNodeByPathToFrontendResponse, sessionId: string}>;
 
         /**
          * Requests that a batch of nodes is sent to the caller given their backend node ids.
+         * @experimental
          */
         pushNodesByBackendIdsToFrontend(params: Protocol.DOM.PushNodesByBackendIdsToFrontendRequest): Promise<{id: number, result: Protocol.DOM.PushNodesByBackendIdsToFrontendResponse, sessionId: string}>;
 
@@ -1600,16 +1683,19 @@ export namespace ProtocolTestsProxyApi {
          * Returns NodeIds of current top layer elements.
          * Top layer is rendered closest to the user within a viewport, therefore its elements always
          * appear on top of all other content.
+         * @experimental
          */
         getTopLayerElements(): Promise<{id: number, result: Protocol.DOM.GetTopLayerElementsResponse, sessionId: string}>;
 
         /**
          * Returns the NodeId of the matched element according to certain relations.
+         * @experimental
          */
         getElementByRelation(params: Protocol.DOM.GetElementByRelationRequest): Promise<{id: number, result: Protocol.DOM.GetElementByRelationResponse, sessionId: string}>;
 
         /**
          * Re-does the last undone action.
+         * @experimental
          */
         redo(): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -1660,28 +1746,33 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Sets if stack traces should be captured for Nodes. See `Node.getNodeStackTraces`. Default is disabled.
+         * @experimental
          */
         setNodeStackTracesEnabled(params: Protocol.DOM.SetNodeStackTracesEnabledRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Gets stack traces associated with a Node. As of now, only provides stack trace for Node creation.
+         * @experimental
          */
         getNodeStackTraces(params: Protocol.DOM.GetNodeStackTracesRequest): Promise<{id: number, result: Protocol.DOM.GetNodeStackTracesResponse, sessionId: string}>;
 
         /**
          * Returns file information for the given
          * File wrapper.
+         * @experimental
          */
         getFileInfo(params: Protocol.DOM.GetFileInfoRequest): Promise<{id: number, result: Protocol.DOM.GetFileInfoResponse, sessionId: string}>;
 
         /**
          * Returns list of detached nodes
+         * @experimental
          */
         getDetachedDomNodes(): Promise<{id: number, result: Protocol.DOM.GetDetachedDomNodesResponse, sessionId: string}>;
 
         /**
          * Enables console to refer to the node with given id via $x (see Command Line API for more details
          * $x functions).
+         * @experimental
          */
         setInspectedNode(params: Protocol.DOM.SetInspectedNodeRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -1702,11 +1793,13 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Undoes the last performed action.
+         * @experimental
          */
         undo(): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Returns iframe node that owns iframe with the given domain.
+         * @experimental
          */
         getFrameOwner(params: Protocol.DOM.GetFrameOwnerRequest): Promise<{id: number, result: Protocol.DOM.GetFrameOwnerResponse, sessionId: string}>;
 
@@ -1716,24 +1809,28 @@ export namespace ProtocolTestsProxyApi {
          * scroll-state or anchored elements. If no axes are provided and
          * queriesScrollState is false, the style container is returned, which is the
          * direct parent or the closest element with a matching container-name.
+         * @experimental
          */
         getContainerForNode(params: Protocol.DOM.GetContainerForNodeRequest): Promise<{id: number, result: Protocol.DOM.GetContainerForNodeResponse, sessionId: string}>;
 
         /**
          * Returns the descendants of a container query container that have
          * container queries against this container.
+         * @experimental
          */
         getQueryingDescendantsForContainer(params: Protocol.DOM.GetQueryingDescendantsForContainerRequest): Promise<{id: number, result: Protocol.DOM.GetQueryingDescendantsForContainerResponse, sessionId: string}>;
 
         /**
          * Returns the target anchor element of the given anchor query according to
          * https://www.w3.org/TR/css-anchor-position-1/#target.
+         * @experimental
          */
         getAnchorElement(params: Protocol.DOM.GetAnchorElementRequest): Promise<{id: number, result: Protocol.DOM.GetAnchorElementResponse, sessionId: string}>;
 
         /**
          * When enabling, this API force-opens the popover identified by nodeId
          * and keeps it open until disabled.
+         * @experimental
          */
         forceShowPopover(params: Protocol.DOM.ForceShowPopoverRequest): Promise<{id: number, result: Protocol.DOM.ForceShowPopoverResponse, sessionId: string}>;
 
@@ -1781,6 +1878,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Called when distribution is changed.
+         * @experimental
          */
         onDistributedNodesUpdated(listener: (event: { params: Protocol.DOM.DistributedNodesUpdatedEvent }) => void): void;
         offDistributedNodesUpdated(listener: (event: { params: Protocol.DOM.DistributedNodesUpdatedEvent }) => void): void;
@@ -1795,6 +1893,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when `Element`'s inline style is modified via a CSS property modification.
+         * @experimental
          */
         onInlineStyleInvalidated(listener: (event: { params: Protocol.DOM.InlineStyleInvalidatedEvent }) => void): void;
         offInlineStyleInvalidated(listener: (event: { params: Protocol.DOM.InlineStyleInvalidatedEvent }) => void): void;
@@ -1802,6 +1901,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Called when a pseudo element is added to an element.
+         * @experimental
          */
         onPseudoElementAdded(listener: (event: { params: Protocol.DOM.PseudoElementAddedEvent }) => void): void;
         offPseudoElementAdded(listener: (event: { params: Protocol.DOM.PseudoElementAddedEvent }) => void): void;
@@ -1809,6 +1909,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Called when top layer elements are changed.
+         * @experimental
          */
         onTopLayerElementsUpdated(listener: () => void): void;
         offTopLayerElementsUpdated(listener: () => void): void;
@@ -1816,6 +1917,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when a node's scrollability state changes.
+         * @experimental
          */
         onScrollableFlagUpdated(listener: (event: { params: Protocol.DOM.ScrollableFlagUpdatedEvent }) => void): void;
         offScrollableFlagUpdated(listener: (event: { params: Protocol.DOM.ScrollableFlagUpdatedEvent }) => void): void;
@@ -1823,6 +1925,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Called when a pseudo element is removed from an element.
+         * @experimental
          */
         onPseudoElementRemoved(listener: (event: { params: Protocol.DOM.PseudoElementRemovedEvent }) => void): void;
         offPseudoElementRemoved(listener: (event: { params: Protocol.DOM.PseudoElementRemovedEvent }) => void): void;
@@ -1838,6 +1941,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Called when shadow root is popped from the element.
+         * @experimental
          */
         onShadowRootPopped(listener: (event: { params: Protocol.DOM.ShadowRootPoppedEvent }) => void): void;
         offShadowRootPopped(listener: (event: { params: Protocol.DOM.ShadowRootPoppedEvent }) => void): void;
@@ -1845,6 +1949,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Called when shadow root is pushed into the element.
+         * @experimental
          */
         onShadowRootPushed(listener: (event: { params: Protocol.DOM.ShadowRootPushedEvent }) => void): void;
         offShadowRootPushed(listener: (event: { params: Protocol.DOM.ShadowRootPushedEvent }) => void): void;
@@ -1870,6 +1975,8 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Removes breakpoint on particular native event.
+         * @deprecated
+         * @experimental
          */
         removeInstrumentationBreakpoint(params: Protocol.DOMDebugger.RemoveInstrumentationBreakpointRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -1880,6 +1987,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Sets breakpoint on particular CSP violations.
+         * @experimental
          */
         setBreakOnCSPViolation(params: Protocol.DOMDebugger.SetBreakOnCSPViolationRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -1895,6 +2003,8 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Sets breakpoint on particular native event.
+         * @deprecated
+         * @experimental
          */
         setInstrumentationBreakpoint(params: Protocol.DOMDebugger.SetInstrumentationBreakpointRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -1939,6 +2049,7 @@ export namespace ProtocolTestsProxyApi {
          * template contents, and imported documents) in a flattened array, as well as layout and
          * white-listed computed style information for the nodes. Shadow DOM in the returned DOM tree is
          * flattened.
+         * @deprecated
          */
         getSnapshot(params: Protocol.DOMSnapshot.GetSnapshotRequest): Promise<{id: number, result: Protocol.DOMSnapshot.GetSnapshotResponse, sessionId: string}>;
 
@@ -2005,6 +2116,7 @@ export namespace ProtocolTestsProxyApi {
     export interface EmulationApi {
         /**
          * Tells whether emulation is supported.
+         * @deprecated
          */
         canEmulate(): Promise<{id: number, result: Protocol.Emulation.CanEmulateResponse, sessionId: string}>;
 
@@ -2020,16 +2132,19 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Requests that page scale factor is reset to initial values.
+         * @experimental
          */
         resetPageScaleFactor(): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Enables or disables simulating a focused and active page.
+         * @experimental
          */
         setFocusEmulationEnabled(params: Protocol.Emulation.SetFocusEmulationEnabledRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Automatically render all web contents using a dark theme.
+         * @experimental
          */
         setAutoDarkModeOverride(params: Protocol.Emulation.SetAutoDarkModeOverrideRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2047,6 +2162,7 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Overrides the values for env(safe-area-inset-*) and env(safe-area-max-inset-*). Unset values will cause the
          * respective variables to be undefined, even if previously overridden.
+         * @experimental
          */
         setSafeAreaInsetsOverride(params: Protocol.Emulation.SetSafeAreaInsetsOverrideRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2060,6 +2176,7 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Start reporting the given posture value to the Device Posture API.
          * This override can also be set in setDeviceMetricsOverride().
+         * @experimental
          */
         setDevicePostureOverride(params: Protocol.Emulation.SetDevicePostureOverrideRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2068,12 +2185,14 @@ export namespace ProtocolTestsProxyApi {
          * or setDevicePostureOverride() and starts using posture information from the
          * platform again.
          * Does nothing if no override is set.
+         * @experimental
          */
         clearDevicePostureOverride(): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Start using the given display features to pupulate the Viewport Segments API.
          * This override can also be set in setDeviceMetricsOverride().
+         * @experimental
          */
         setDisplayFeaturesOverride(params: Protocol.Emulation.SetDisplayFeaturesOverrideRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2082,13 +2201,23 @@ export namespace ProtocolTestsProxyApi {
          * or setDisplayFeaturesOverride() and starts using display features from the
          * platform again.
          * Does nothing if no override is set.
+         * @experimental
          */
         clearDisplayFeaturesOverride(): Promise<{id: number, result: void, sessionId: string}>;
 
+        /**
+         * @experimental
+         */
         setScrollbarsHidden(params: Protocol.Emulation.SetScrollbarsHiddenRequest): Promise<{id: number, result: void, sessionId: string}>;
 
+        /**
+         * @experimental
+         */
         setDocumentCookieDisabled(params: Protocol.Emulation.SetDocumentCookieDisabledRequest): Promise<{id: number, result: void, sessionId: string}>;
 
+        /**
+         * @experimental
+         */
         setEmitTouchEventsForMouse(params: Protocol.Emulation.SetEmitTouchEventsForMouseRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
@@ -2112,6 +2241,9 @@ export namespace ProtocolTestsProxyApi {
          */
         setGeolocationOverride(params: Protocol.Emulation.SetGeolocationOverrideRequest): Promise<{id: number, result: void, sessionId: string}>;
 
+        /**
+         * @experimental
+         */
         getOverriddenSensorInformation(params: Protocol.Emulation.GetOverriddenSensorInformationRequest): Promise<{id: number, result: Protocol.Emulation.GetOverriddenSensorInformationResponse, sessionId: string}>;
 
         /**
@@ -2120,12 +2252,14 @@ export namespace ProtocolTestsProxyApi {
          * data from a real hardware sensor. Otherwise, existing virtual
          * sensor-backend Sensor objects will fire an error event and new calls to
          * Sensor.start() will attempt to use a real sensor instead.
+         * @experimental
          */
         setSensorOverrideEnabled(params: Protocol.Emulation.SetSensorOverrideEnabledRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Updates the sensor readings reported by a sensor type previously overridden
          * by setSensorOverrideEnabled.
+         * @experimental
          */
         setSensorOverrideReadings(params: Protocol.Emulation.SetSensorOverrideReadingsRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2134,6 +2268,7 @@ export namespace ProtocolTestsProxyApi {
          * Pressure API, so that updates to PressureObserver.observe() are provided
          * via setPressureStateOverride instead of being retrieved from
          * platform-provided telemetry data.
+         * @experimental
          */
         setPressureSourceOverrideEnabled(params: Protocol.Emulation.SetPressureSourceOverrideEnabledRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2142,6 +2277,7 @@ export namespace ProtocolTestsProxyApi {
          * Provides a given pressure state that will be processed and eventually be
          * delivered to PressureObserver users. |source| must have been previously
          * overridden by setPressureSourceOverrideEnabled.
+         * @experimental
          */
         setPressureStateOverride(params: Protocol.Emulation.SetPressureStateOverrideRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2149,6 +2285,7 @@ export namespace ProtocolTestsProxyApi {
          * Provides a given pressure data set that will be processed and eventually be
          * delivered to PressureObserver users. |source| must have been previously
          * overridden by setPressureSourceOverrideEnabled.
+         * @experimental
          */
         setPressureDataOverride(params: Protocol.Emulation.SetPressureDataOverrideRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2164,11 +2301,14 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Overrides value returned by the javascript navigator object.
+         * @deprecated
+         * @experimental
          */
         setNavigatorOverrides(params: Protocol.Emulation.SetNavigatorOverridesRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Sets a specified page scale factor.
+         * @experimental
          */
         setPageScaleFactor(params: Protocol.Emulation.SetPageScaleFactorRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2185,11 +2325,13 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Turns on virtual time for all frames (replacing real-time with a synthetic time source) and sets
          * the current virtual time policy.  Note this supersedes any previous time budget.
+         * @experimental
          */
         setVirtualTimePolicy(params: Protocol.Emulation.SetVirtualTimePolicyRequest): Promise<{id: number, result: Protocol.Emulation.SetVirtualTimePolicyResponse, sessionId: string}>;
 
         /**
          * Overrides default host system locale with the specified one.
+         * @experimental
          */
         setLocaleOverride(params: Protocol.Emulation.SetLocaleOverrideRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2202,16 +2344,25 @@ export namespace ProtocolTestsProxyApi {
          * Resizes the frame/viewport of the page. Note that this does not affect the frame's container
          * (e.g. browser window). Can be used to produce screenshots of the specified size. Not supported
          * on Android.
+         * @deprecated
+         * @experimental
          */
         setVisibleSize(params: Protocol.Emulation.SetVisibleSizeRequest): Promise<{id: number, result: void, sessionId: string}>;
 
+        /**
+         * @experimental
+         */
         setDisabledImageTypes(params: Protocol.Emulation.SetDisabledImageTypesRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Override the value of navigator.connection.saveData
+         * @experimental
          */
         setDataSaverOverride(params: Protocol.Emulation.SetDataSaverOverrideRequest): Promise<{id: number, result: void, sessionId: string}>;
 
+        /**
+         * @experimental
+         */
         setHardwareConcurrencyOverride(params: Protocol.Emulation.SetHardwareConcurrencyOverrideRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
@@ -2222,17 +2373,20 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Allows overriding the automation flag.
+         * @experimental
          */
         setAutomationOverride(params: Protocol.Emulation.SetAutomationOverrideRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Allows overriding the difference between the small and large viewport sizes, which determine the
          * value of the `svh` and `lvh` unit, respectively. Only supported for top-level frames.
+         * @experimental
          */
         setSmallViewportHeightDifferenceOverride(params: Protocol.Emulation.SetSmallViewportHeightDifferenceOverrideRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Notification sent after the virtual time budget for the current VirtualTimePolicy has run out.
+         * @experimental
          */
         onVirtualTimeBudgetExpired(listener: () => void): void;
         offVirtualTimeBudgetExpired(listener: () => void): void;
@@ -2251,11 +2405,13 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Disables headless events for the target.
+         * @deprecated
          */
         disable(): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Enables headless events for the target.
+         * @deprecated
          */
         enable(): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2335,6 +2491,7 @@ export namespace ProtocolTestsProxyApi {
     export interface InputApi {
         /**
          * Dispatches a drag event into the page.
+         * @experimental
          */
         dispatchDragEvent(params: Protocol.Input.DispatchDragEventRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2346,6 +2503,7 @@ export namespace ProtocolTestsProxyApi {
         /**
          * This method emulates inserting text that doesn't come from a key press,
          * for example an emoji keyboard or an IME.
+         * @experimental
          */
         insertText(params: Protocol.Input.InsertTextRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2353,6 +2511,7 @@ export namespace ProtocolTestsProxyApi {
          * This method sets the current candidate text for IME.
          * Use imeCommitComposition to commit the final text.
          * Use imeSetComposition with empty string as text to cancel composition.
+         * @experimental
          */
         imeSetComposition(params: Protocol.Input.ImeSetCompositionRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2373,6 +2532,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Emulates touch event from the mouse event parameters.
+         * @experimental
          */
         emulateTouchFromMouseEvent(params: Protocol.Input.EmulateTouchFromMouseEventRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2384,27 +2544,32 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Prevents default drag and drop behavior and instead emits `Input.dragIntercepted` events.
          * Drag and drop behavior can be directly controlled via `Input.dispatchDragEvent`.
+         * @experimental
          */
         setInterceptDrags(params: Protocol.Input.SetInterceptDragsRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Synthesizes a pinch gesture over a time period by issuing appropriate touch events.
+         * @experimental
          */
         synthesizePinchGesture(params: Protocol.Input.SynthesizePinchGestureRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Synthesizes a scroll gesture over a time period by issuing appropriate touch events.
+         * @experimental
          */
         synthesizeScrollGesture(params: Protocol.Input.SynthesizeScrollGestureRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Synthesizes a tap gesture over a time period by issuing appropriate touch events.
+         * @experimental
          */
         synthesizeTapGesture(params: Protocol.Input.SynthesizeTapGestureRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Emitted only when `Input.setInterceptDrags` is enabled. Use this data with `Input.dispatchDragEvent` to
          * restore normal drag and drop behavior.
+         * @experimental
          */
         onDragIntercepted(listener: (event: { params: Protocol.Input.DragInterceptedEvent }) => void): void;
         offDragIntercepted(listener: (event: { params: Protocol.Input.DragInterceptedEvent }) => void): void;
@@ -2600,26 +2765,31 @@ export namespace ProtocolTestsProxyApi {
     export interface NetworkApi {
         /**
          * Sets a list of content encodings that will be accepted. Empty list means no encoding is accepted.
+         * @experimental
          */
         setAcceptedEncodings(params: Protocol.Network.SetAcceptedEncodingsRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Clears accepted encodings set by setAcceptedEncodings
+         * @experimental
          */
         clearAcceptedEncodingsOverride(): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Tells whether clearing browser cache is supported.
+         * @deprecated
          */
         canClearBrowserCache(): Promise<{id: number, result: Protocol.Network.CanClearBrowserCacheResponse, sessionId: string}>;
 
         /**
          * Tells whether clearing browser cookies is supported.
+         * @deprecated
          */
         canClearBrowserCookies(): Promise<{id: number, result: Protocol.Network.CanClearBrowserCookiesResponse, sessionId: string}>;
 
         /**
          * Tells whether emulation of network conditions is supported.
+         * @deprecated
          */
         canEmulateNetworkConditions(): Promise<{id: number, result: Protocol.Network.CanEmulateNetworkConditionsResponse, sessionId: string}>;
 
@@ -2639,6 +2809,8 @@ export namespace ProtocolTestsProxyApi {
          * fetch occurs as a result which encounters a redirect an additional Network.requestIntercepted
          * event will be sent with the same InterceptionId.
          * Deprecated, use Fetch.continueRequest, Fetch.fulfillRequest and Fetch.failRequest instead.
+         * @deprecated
+         * @experimental
          */
         continueInterceptedRequest(params: Protocol.Network.ContinueInterceptedRequestRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2666,11 +2838,13 @@ export namespace ProtocolTestsProxyApi {
          * Returns all browser cookies. Depending on the backend support, will return detailed cookie
          * information in the `cookies` field.
          * Deprecated. Use Storage.getCookies instead.
+         * @deprecated
          */
         getAllCookies(): Promise<{id: number, result: Protocol.Network.GetAllCookiesResponse, sessionId: string}>;
 
         /**
          * Returns the DER-encoded certificate.
+         * @experimental
          */
         getCertificate(params: Protocol.Network.GetCertificateRequest): Promise<{id: number, result: Protocol.Network.GetCertificateResponse, sessionId: string}>;
 
@@ -2692,6 +2866,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Returns content served for the given currently intercepted request.
+         * @experimental
          */
         getResponseBodyForInterception(params: Protocol.Network.GetResponseBodyForInterceptionRequest): Promise<{id: number, result: Protocol.Network.GetResponseBodyForInterceptionResponse, sessionId: string}>;
 
@@ -2700,6 +2875,7 @@ export namespace ProtocolTestsProxyApi {
          * the intercepted request can't be continued as is -- you either need to cancel it or to provide
          * the response body. The stream only supports sequential read, IO.read will fail if the position
          * is specified.
+         * @experimental
          */
         takeResponseBodyForInterceptionAsStream(params: Protocol.Network.TakeResponseBodyForInterceptionAsStreamRequest): Promise<{id: number, result: Protocol.Network.TakeResponseBodyForInterceptionAsStreamResponse, sessionId: string}>;
 
@@ -2707,16 +2883,19 @@ export namespace ProtocolTestsProxyApi {
          * This method sends a new XMLHttpRequest which is identical to the original one. The following
          * parameters should be identical: method, url, async, request body, extra headers, withCredentials
          * attribute, user, password.
+         * @experimental
          */
         replayXHR(params: Protocol.Network.ReplayXHRRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Searches for given string in response content.
+         * @experimental
          */
         searchInResponseBody(params: Protocol.Network.SearchInResponseBodyRequest): Promise<{id: number, result: Protocol.Network.SearchInResponseBodyResponse, sessionId: string}>;
 
         /**
          * Blocks URLs from loading.
+         * @experimental
          */
         setBlockedURLs(params: Protocol.Network.SetBlockedURLsRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2747,12 +2926,15 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Specifies whether to attach a page script stack id in requests
+         * @experimental
          */
         setAttachDebugStack(params: Protocol.Network.SetAttachDebugStackRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Sets the requests to intercept that match the provided patterns and optionally resource types.
          * Deprecated, please use Fetch.enable instead.
+         * @deprecated
+         * @experimental
          */
         setRequestInterception(params: Protocol.Network.SetRequestInterceptionRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2764,28 +2946,33 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Enables streaming of the response for the given requestId.
          * If enabled, the dataReceived event contains the data that was received during streaming.
+         * @experimental
          */
         streamResourceContent(params: Protocol.Network.StreamResourceContentRequest): Promise<{id: number, result: Protocol.Network.StreamResourceContentResponse, sessionId: string}>;
 
         /**
          * Returns information about the COEP/COOP isolation status.
+         * @experimental
          */
         getSecurityIsolationStatus(params: Protocol.Network.GetSecurityIsolationStatusRequest): Promise<{id: number, result: Protocol.Network.GetSecurityIsolationStatusResponse, sessionId: string}>;
 
         /**
          * Enables tracking for the Reporting API, events generated by the Reporting API will now be delivered to the client.
          * Enabling triggers 'reportingApiReportAdded' for all existing reports.
+         * @experimental
          */
         enableReportingApi(params: Protocol.Network.EnableReportingApiRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Fetches the resource and returns the content.
+         * @experimental
          */
         loadNetworkResource(params: Protocol.Network.LoadNetworkResourceRequest): Promise<{id: number, result: Protocol.Network.LoadNetworkResourceResponse, sessionId: string}>;
 
         /**
          * Sets Controls for third-party cookie access
          * Page reload is required before the new cookie behavior will be observed
+         * @experimental
          */
         setCookieControls(params: Protocol.Network.SetCookieControlsRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -2821,6 +3008,8 @@ export namespace ProtocolTestsProxyApi {
          * Details of an intercepted HTTP request, which must be either allowed, blocked, modified or
          * mocked.
          * Deprecated, use Fetch.requestPaused instead.
+         * @deprecated
+         * @experimental
          */
         onRequestIntercepted(listener: (event: { params: Protocol.Network.RequestInterceptedEvent }) => void): void;
         offRequestIntercepted(listener: (event: { params: Protocol.Network.RequestInterceptedEvent }) => void): void;
@@ -2842,6 +3031,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when resource loading priority is changed
+         * @experimental
          */
         onResourceChangedPriority(listener: (event: { params: Protocol.Network.ResourceChangedPriorityEvent }) => void): void;
         offResourceChangedPriority(listener: (event: { params: Protocol.Network.ResourceChangedPriorityEvent }) => void): void;
@@ -2849,6 +3039,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when a signed exchange was received over the network
+         * @experimental
          */
         onSignedExchangeReceived(listener: (event: { params: Protocol.Network.SignedExchangeReceivedEvent }) => void): void;
         offSignedExchangeReceived(listener: (event: { params: Protocol.Network.SignedExchangeReceivedEvent }) => void): void;
@@ -2933,6 +3124,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired upon direct_socket.TCPSocket creation.
+         * @experimental
          */
         onDirectTCPSocketCreated(listener: (event: { params: Protocol.Network.DirectTCPSocketCreatedEvent }) => void): void;
         offDirectTCPSocketCreated(listener: (event: { params: Protocol.Network.DirectTCPSocketCreatedEvent }) => void): void;
@@ -2940,6 +3132,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when direct_socket.TCPSocket connection is opened.
+         * @experimental
          */
         onDirectTCPSocketOpened(listener: (event: { params: Protocol.Network.DirectTCPSocketOpenedEvent }) => void): void;
         offDirectTCPSocketOpened(listener: (event: { params: Protocol.Network.DirectTCPSocketOpenedEvent }) => void): void;
@@ -2947,6 +3140,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when direct_socket.TCPSocket is aborted.
+         * @experimental
          */
         onDirectTCPSocketAborted(listener: (event: { params: Protocol.Network.DirectTCPSocketAbortedEvent }) => void): void;
         offDirectTCPSocketAborted(listener: (event: { params: Protocol.Network.DirectTCPSocketAbortedEvent }) => void): void;
@@ -2954,6 +3148,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when direct_socket.TCPSocket is closed.
+         * @experimental
          */
         onDirectTCPSocketClosed(listener: (event: { params: Protocol.Network.DirectTCPSocketClosedEvent }) => void): void;
         offDirectTCPSocketClosed(listener: (event: { params: Protocol.Network.DirectTCPSocketClosedEvent }) => void): void;
@@ -2961,6 +3156,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when data is sent to tcp direct socket stream.
+         * @experimental
          */
         onDirectTCPSocketChunkSent(listener: (event: { params: Protocol.Network.DirectTCPSocketChunkSentEvent }) => void): void;
         offDirectTCPSocketChunkSent(listener: (event: { params: Protocol.Network.DirectTCPSocketChunkSentEvent }) => void): void;
@@ -2968,6 +3164,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when data is received from tcp direct socket stream.
+         * @experimental
          */
         onDirectTCPSocketChunkReceived(listener: (event: { params: Protocol.Network.DirectTCPSocketChunkReceivedEvent }) => void): void;
         offDirectTCPSocketChunkReceived(listener: (event: { params: Protocol.Network.DirectTCPSocketChunkReceivedEvent }) => void): void;
@@ -2975,6 +3172,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired upon direct_socket.UDPSocket creation.
+         * @experimental
          */
         onDirectUDPSocketCreated(listener: (event: { params: Protocol.Network.DirectUDPSocketCreatedEvent }) => void): void;
         offDirectUDPSocketCreated(listener: (event: { params: Protocol.Network.DirectUDPSocketCreatedEvent }) => void): void;
@@ -2982,6 +3180,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when direct_socket.UDPSocket connection is opened.
+         * @experimental
          */
         onDirectUDPSocketOpened(listener: (event: { params: Protocol.Network.DirectUDPSocketOpenedEvent }) => void): void;
         offDirectUDPSocketOpened(listener: (event: { params: Protocol.Network.DirectUDPSocketOpenedEvent }) => void): void;
@@ -2989,6 +3188,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when direct_socket.UDPSocket is aborted.
+         * @experimental
          */
         onDirectUDPSocketAborted(listener: (event: { params: Protocol.Network.DirectUDPSocketAbortedEvent }) => void): void;
         offDirectUDPSocketAborted(listener: (event: { params: Protocol.Network.DirectUDPSocketAbortedEvent }) => void): void;
@@ -2996,6 +3196,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when direct_socket.UDPSocket is closed.
+         * @experimental
          */
         onDirectUDPSocketClosed(listener: (event: { params: Protocol.Network.DirectUDPSocketClosedEvent }) => void): void;
         offDirectUDPSocketClosed(listener: (event: { params: Protocol.Network.DirectUDPSocketClosedEvent }) => void): void;
@@ -3003,6 +3204,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when message is sent to udp direct socket stream.
+         * @experimental
          */
         onDirectUDPSocketChunkSent(listener: (event: { params: Protocol.Network.DirectUDPSocketChunkSentEvent }) => void): void;
         offDirectUDPSocketChunkSent(listener: (event: { params: Protocol.Network.DirectUDPSocketChunkSentEvent }) => void): void;
@@ -3010,6 +3212,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when message is received from udp direct socket stream.
+         * @experimental
          */
         onDirectUDPSocketChunkReceived(listener: (event: { params: Protocol.Network.DirectUDPSocketChunkReceivedEvent }) => void): void;
         offDirectUDPSocketChunkReceived(listener: (event: { params: Protocol.Network.DirectUDPSocketChunkReceivedEvent }) => void): void;
@@ -3020,6 +3223,7 @@ export namespace ProtocolTestsProxyApi {
          * network stack. Not every requestWillBeSent event will have an additional
          * requestWillBeSentExtraInfo fired for it, and there is no guarantee whether requestWillBeSent
          * or requestWillBeSentExtraInfo will be fired first for the same request.
+         * @experimental
          */
         onRequestWillBeSentExtraInfo(listener: (event: { params: Protocol.Network.RequestWillBeSentExtraInfoEvent }) => void): void;
         offRequestWillBeSentExtraInfo(listener: (event: { params: Protocol.Network.RequestWillBeSentExtraInfoEvent }) => void): void;
@@ -3029,6 +3233,7 @@ export namespace ProtocolTestsProxyApi {
          * Fired when additional information about a responseReceived event is available from the network
          * stack. Not every responseReceived event will have an additional responseReceivedExtraInfo for
          * it, and responseReceivedExtraInfo may be fired before or after responseReceived.
+         * @experimental
          */
         onResponseReceivedExtraInfo(listener: (event: { params: Protocol.Network.ResponseReceivedExtraInfoEvent }) => void): void;
         offResponseReceivedExtraInfo(listener: (event: { params: Protocol.Network.ResponseReceivedExtraInfoEvent }) => void): void;
@@ -3038,6 +3243,7 @@ export namespace ProtocolTestsProxyApi {
          * Fired when 103 Early Hints headers is received in addition to the common response.
          * Not every responseReceived event will have an responseReceivedEarlyHints fired.
          * Only one responseReceivedEarlyHints may be fired for eached responseReceived event.
+         * @experimental
          */
         onResponseReceivedEarlyHints(listener: (event: { params: Protocol.Network.ResponseReceivedEarlyHintsEvent }) => void): void;
         offResponseReceivedEarlyHints(listener: (event: { params: Protocol.Network.ResponseReceivedEarlyHintsEvent }) => void): void;
@@ -3048,6 +3254,7 @@ export namespace ProtocolTestsProxyApi {
          * the type of the operation and whether the operation succeeded or
          * failed, the event is fired before the corresponding request was sent
          * or after the response was received.
+         * @experimental
          */
         onTrustTokenOperationDone(listener: (event: { params: Protocol.Network.TrustTokenOperationDoneEvent }) => void): void;
         offTrustTokenOperationDone(listener: (event: { params: Protocol.Network.TrustTokenOperationDoneEvent }) => void): void;
@@ -3055,6 +3262,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired once security policy has been updated.
+         * @experimental
          */
         onPolicyUpdated(listener: () => void): void;
         offPolicyUpdated(listener: () => void): void;
@@ -3063,6 +3271,7 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Fired once when parsing the .wbn file has succeeded.
          * The event contains the information about the web bundle contents.
+         * @experimental
          */
         onSubresourceWebBundleMetadataReceived(listener: (event: { params: Protocol.Network.SubresourceWebBundleMetadataReceivedEvent }) => void): void;
         offSubresourceWebBundleMetadataReceived(listener: (event: { params: Protocol.Network.SubresourceWebBundleMetadataReceivedEvent }) => void): void;
@@ -3070,6 +3279,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired once when parsing the .wbn file has failed.
+         * @experimental
          */
         onSubresourceWebBundleMetadataError(listener: (event: { params: Protocol.Network.SubresourceWebBundleMetadataErrorEvent }) => void): void;
         offSubresourceWebBundleMetadataError(listener: (event: { params: Protocol.Network.SubresourceWebBundleMetadataErrorEvent }) => void): void;
@@ -3078,6 +3288,7 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Fired when handling requests for resources within a .wbn file.
          * Note: this will only be fired for resources that are requested by the webpage.
+         * @experimental
          */
         onSubresourceWebBundleInnerResponseParsed(listener: (event: { params: Protocol.Network.SubresourceWebBundleInnerResponseParsedEvent }) => void): void;
         offSubresourceWebBundleInnerResponseParsed(listener: (event: { params: Protocol.Network.SubresourceWebBundleInnerResponseParsedEvent }) => void): void;
@@ -3085,6 +3296,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when request for resources within a .wbn file failed.
+         * @experimental
          */
         onSubresourceWebBundleInnerResponseError(listener: (event: { params: Protocol.Network.SubresourceWebBundleInnerResponseErrorEvent }) => void): void;
         offSubresourceWebBundleInnerResponseError(listener: (event: { params: Protocol.Network.SubresourceWebBundleInnerResponseErrorEvent }) => void): void;
@@ -3093,15 +3305,22 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Is sent whenever a new report is added.
          * And after 'enableReportingApi' for all existing reports.
+         * @experimental
          */
         onReportingApiReportAdded(listener: (event: { params: Protocol.Network.ReportingApiReportAddedEvent }) => void): void;
         offReportingApiReportAdded(listener: (event: { params: Protocol.Network.ReportingApiReportAddedEvent }) => void): void;
         onceReportingApiReportAdded(eventMatcher?: (event: { params: Protocol.Network.ReportingApiReportAddedEvent }) => boolean): Promise<{ params: Protocol.Network.ReportingApiReportAddedEvent }>;
 
+        /**
+         * @experimental
+         */
         onReportingApiReportUpdated(listener: (event: { params: Protocol.Network.ReportingApiReportUpdatedEvent }) => void): void;
         offReportingApiReportUpdated(listener: (event: { params: Protocol.Network.ReportingApiReportUpdatedEvent }) => void): void;
         onceReportingApiReportUpdated(eventMatcher?: (event: { params: Protocol.Network.ReportingApiReportUpdatedEvent }) => boolean): Promise<{ params: Protocol.Network.ReportingApiReportUpdatedEvent }>;
 
+        /**
+         * @experimental
+         */
         onReportingApiEndpointsChangedForOrigin(listener: (event: { params: Protocol.Network.ReportingApiEndpointsChangedForOriginEvent }) => void): void;
         offReportingApiEndpointsChangedForOrigin(listener: (event: { params: Protocol.Network.ReportingApiEndpointsChangedForOriginEvent }) => void): void;
         onceReportingApiEndpointsChangedForOrigin(eventMatcher?: (event: { params: Protocol.Network.ReportingApiEndpointsChangedForOriginEvent }) => boolean): Promise<{ params: Protocol.Network.ReportingApiEndpointsChangedForOriginEvent }>;
@@ -3144,6 +3363,7 @@ export namespace ProtocolTestsProxyApi {
          * Deprecated: Doesn't work reliably and cannot be fixed due to process
          * separation (the owner node might be in a different process). Determine
          * the owner node in the client and use highlightNode.
+         * @deprecated
          */
         highlightFrame(params: Protocol.Overlay.HighlightFrameRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -3220,11 +3440,13 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Deprecated, no longer has any effect.
+         * @deprecated
          */
         setShowHitTestBorders(params: Protocol.Overlay.SetShowHitTestBordersRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Deprecated, no longer has any effect.
+         * @deprecated
          */
         setShowWebVitals(params: Protocol.Overlay.SetShowWebVitalsRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -3282,6 +3504,8 @@ export namespace ProtocolTestsProxyApi {
     export interface PageApi {
         /**
          * Deprecated, please use addScriptToEvaluateOnNewDocument instead.
+         * @deprecated
+         * @experimental
          */
         addScriptToEvaluateOnLoad(params: Protocol.Page.AddScriptToEvaluateOnLoadRequest): Promise<{id: number, result: Protocol.Page.AddScriptToEvaluateOnLoadResponse, sessionId: string}>;
 
@@ -3303,21 +3527,27 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Returns a snapshot of the page as a string. For MHTML format, the serialization includes
          * iframes, shadow DOM, external resources, and element-inline styles.
+         * @experimental
          */
         captureSnapshot(params: Protocol.Page.CaptureSnapshotRequest): Promise<{id: number, result: Protocol.Page.CaptureSnapshotResponse, sessionId: string}>;
 
         /**
          * Clears the overridden device metrics.
+         * @deprecated
+         * @experimental
          */
         clearDeviceMetricsOverride(): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Clears the overridden Device Orientation.
+         * @deprecated
+         * @experimental
          */
         clearDeviceOrientationOverride(): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Clears the overridden Geolocation Position and Error.
+         * @deprecated
          */
         clearGeolocationOverride(): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -3328,6 +3558,8 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Deletes browser cookie with given name, domain and path.
+         * @deprecated
+         * @experimental
          */
         deleteCookie(params: Protocol.Page.DeleteCookieRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -3350,19 +3582,28 @@ export namespace ProtocolTestsProxyApi {
          */
         getAppManifest(params: Protocol.Page.GetAppManifestRequest): Promise<{id: number, result: Protocol.Page.GetAppManifestResponse, sessionId: string}>;
 
+        /**
+         * @experimental
+         */
         getInstallabilityErrors(): Promise<{id: number, result: Protocol.Page.GetInstallabilityErrorsResponse, sessionId: string}>;
 
         /**
          * Deprecated because it's not guaranteed that the returned icon is in fact the one used for PWA installation.
+         * @deprecated
+         * @experimental
          */
         getManifestIcons(): Promise<{id: number, result: Protocol.Page.GetManifestIconsResponse, sessionId: string}>;
 
         /**
          * Returns the unique (PWA) app id.
          * Only returns values if the feature flag 'WebAppEnableManifestId' is enabled
+         * @experimental
          */
         getAppId(): Promise<{id: number, result: Protocol.Page.GetAppIdResponse, sessionId: string}>;
 
+        /**
+         * @experimental
+         */
         getAdScriptAncestry(params: Protocol.Page.GetAdScriptAncestryRequest): Promise<{id: number, result: Protocol.Page.GetAdScriptAncestryResponse, sessionId: string}>;
 
         /**
@@ -3387,11 +3628,13 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Returns content of the given resource.
+         * @experimental
          */
         getResourceContent(params: Protocol.Page.GetResourceContentRequest): Promise<{id: number, result: Protocol.Page.GetResourceContentResponse, sessionId: string}>;
 
         /**
          * Returns present frame / resource tree structure.
+         * @experimental
          */
         getResourceTree(): Promise<{id: number, result: Protocol.Page.GetResourceTreeResponse, sessionId: string}>;
 
@@ -3422,6 +3665,8 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Deprecated, please use removeScriptToEvaluateOnNewDocument instead.
+         * @deprecated
+         * @experimental
          */
         removeScriptToEvaluateOnLoad(params: Protocol.Page.RemoveScriptToEvaluateOnLoadRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -3432,16 +3677,19 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Acknowledges that a screencast frame has been received by the frontend.
+         * @experimental
          */
         screencastFrameAck(params: Protocol.Page.ScreencastFrameAckRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Searches for given string in resource content.
+         * @experimental
          */
         searchInResource(params: Protocol.Page.SearchInResourceRequest): Promise<{id: number, result: Protocol.Page.SearchInResourceResponse, sessionId: string}>;
 
         /**
          * Enable Chrome's experimental ad filter on all sites.
+         * @experimental
          */
         setAdBlockingEnabled(params: Protocol.Page.SetAdBlockingEnabledRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -3452,11 +3700,13 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Get Permissions Policy state on given frame.
+         * @experimental
          */
         getPermissionsPolicyState(params: Protocol.Page.GetPermissionsPolicyStateRequest): Promise<{id: number, result: Protocol.Page.GetPermissionsPolicyStateResponse, sessionId: string}>;
 
         /**
          * Get Origin Trials on given frame.
+         * @experimental
          */
         getOriginTrials(params: Protocol.Page.GetOriginTrialsRequest): Promise<{id: number, result: Protocol.Page.GetOriginTrialsResponse, sessionId: string}>;
 
@@ -3464,21 +3714,27 @@ export namespace ProtocolTestsProxyApi {
          * Overrides the values of device screen dimensions (window.screen.width, window.screen.height,
          * window.innerWidth, window.innerHeight, and "device-width"/"device-height"-related CSS media
          * query results).
+         * @deprecated
+         * @experimental
          */
         setDeviceMetricsOverride(params: Protocol.Page.SetDeviceMetricsOverrideRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Overrides the Device Orientation.
+         * @deprecated
+         * @experimental
          */
         setDeviceOrientationOverride(params: Protocol.Page.SetDeviceOrientationOverrideRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Set generic font families.
+         * @experimental
          */
         setFontFamilies(params: Protocol.Page.SetFontFamiliesRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Set default font sizes.
+         * @experimental
          */
         setFontSizes(params: Protocol.Page.SetFontSizesRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -3489,12 +3745,15 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Set the behavior when downloading a file.
+         * @deprecated
+         * @experimental
          */
         setDownloadBehavior(params: Protocol.Page.SetDownloadBehaviorRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Overrides the Geolocation Position or Error. Omitting any of the parameters emulates position
          * unavailable.
+         * @deprecated
          */
         setGeolocationOverride(params: Protocol.Page.SetGeolocationOverrideRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -3505,11 +3764,14 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Toggles mouse event-based touch event emulation.
+         * @deprecated
+         * @experimental
          */
         setTouchEmulationEnabled(params: Protocol.Page.SetTouchEmulationEnabledRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Starts sending each frame using the `screencastFrame` event.
+         * @experimental
          */
         startScreencast(params: Protocol.Page.StartScreencastRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -3520,6 +3782,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Crashes renderer on the IO thread, generates minidumps.
+         * @experimental
          */
         crash(): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -3532,11 +3795,13 @@ export namespace ProtocolTestsProxyApi {
          * Tries to update the web lifecycle state of the page.
          * It will transition the page to the given state according to:
          * https://github.com/WICG/web-lifecycle/
+         * @experimental
          */
         setWebLifecycleState(params: Protocol.Page.SetWebLifecycleStateRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Stops sending each frame in the `screencastFrame`.
+         * @experimental
          */
         stopScreencast(): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -3547,39 +3812,46 @@ export namespace ProtocolTestsProxyApi {
          * When script with a matching URL is encountered, the cache is optionally
          * produced upon backend discretion, based on internal heuristics.
          * See also: `Page.compilationCacheProduced`.
+         * @experimental
          */
         produceCompilationCache(params: Protocol.Page.ProduceCompilationCacheRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Seeds compilation cache for given url. Compilation cache does not survive
          * cross-process navigation.
+         * @experimental
          */
         addCompilationCache(params: Protocol.Page.AddCompilationCacheRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Clears seeded compilation cache.
+         * @experimental
          */
         clearCompilationCache(): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Sets the Secure Payment Confirmation transaction mode.
          * https://w3c.github.io/secure-payment-confirmation/#sctn-automation-set-spc-transaction-mode
+         * @experimental
          */
         setSPCTransactionMode(params: Protocol.Page.SetSPCTransactionModeRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Extensions for Custom Handlers API:
          * https://html.spec.whatwg.org/multipage/system-state.html#rph-automation
+         * @experimental
          */
         setRPHRegistrationMode(params: Protocol.Page.SetRPHRegistrationModeRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Generates a report for testing.
+         * @experimental
          */
         generateTestReport(params: Protocol.Page.GenerateTestReportRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Pauses page execution. Can be resumed using generic Runtime.runIfWaitingForDebugger.
+         * @experimental
          */
         waitForDebugger(): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -3598,6 +3870,7 @@ export namespace ProtocolTestsProxyApi {
          * for more details.
          * 
          * TODO(https://crbug.com/1440085): Remove this once Puppeteer supports tab targets.
+         * @experimental
          */
         setPrerenderingAllowed(params: Protocol.Page.SetPrerenderingAllowedRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -3621,6 +3894,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when frame no longer has a scheduled navigation.
+         * @deprecated
          */
         onFrameClearedScheduledNavigation(listener: (event: { params: Protocol.Page.FrameClearedScheduledNavigationEvent }) => void): void;
         offFrameClearedScheduledNavigation(listener: (event: { params: Protocol.Page.FrameClearedScheduledNavigationEvent }) => void): void;
@@ -3636,6 +3910,7 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Fired before frame subtree is detached. Emitted before any frame of the
          * subtree is actually detached.
+         * @experimental
          */
         onFrameSubtreeWillBeDetached(listener: (event: { params: Protocol.Page.FrameSubtreeWillBeDetachedEvent }) => void): void;
         offFrameSubtreeWillBeDetached(listener: (event: { params: Protocol.Page.FrameSubtreeWillBeDetachedEvent }) => void): void;
@@ -3650,11 +3925,15 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when opening document to write to.
+         * @experimental
          */
         onDocumentOpened(listener: (event: { params: Protocol.Page.DocumentOpenedEvent }) => void): void;
         offDocumentOpened(listener: (event: { params: Protocol.Page.DocumentOpenedEvent }) => void): void;
         onceDocumentOpened(eventMatcher?: (event: { params: Protocol.Page.DocumentOpenedEvent }) => boolean): Promise<{ params: Protocol.Page.DocumentOpenedEvent }>;
 
+        /**
+         * @experimental
+         */
         onFrameResized(listener: () => void): void;
         offFrameResized(listener: () => void): void;
         onceFrameResized(eventMatcher?: () => boolean): Promise<void>;
@@ -3667,6 +3946,7 @@ export namespace ProtocolTestsProxyApi {
          * can be fired for a single navigation, for example, when a same-document
          * navigation becomes a cross-document navigation (such as in the case of a
          * frameset).
+         * @experimental
          */
         onFrameStartedNavigating(listener: (event: { params: Protocol.Page.FrameStartedNavigatingEvent }) => void): void;
         offFrameStartedNavigating(listener: (event: { params: Protocol.Page.FrameStartedNavigatingEvent }) => void): void;
@@ -3675,6 +3955,7 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Fired when a renderer-initiated navigation is requested.
          * Navigation may still be cancelled after the event is issued.
+         * @experimental
          */
         onFrameRequestedNavigation(listener: (event: { params: Protocol.Page.FrameRequestedNavigationEvent }) => void): void;
         offFrameRequestedNavigation(listener: (event: { params: Protocol.Page.FrameRequestedNavigationEvent }) => void): void;
@@ -3682,6 +3963,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when frame schedules a potential navigation.
+         * @deprecated
          */
         onFrameScheduledNavigation(listener: (event: { params: Protocol.Page.FrameScheduledNavigationEvent }) => void): void;
         offFrameScheduledNavigation(listener: (event: { params: Protocol.Page.FrameScheduledNavigationEvent }) => void): void;
@@ -3689,6 +3971,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when frame has started loading.
+         * @experimental
          */
         onFrameStartedLoading(listener: (event: { params: Protocol.Page.FrameStartedLoadingEvent }) => void): void;
         offFrameStartedLoading(listener: (event: { params: Protocol.Page.FrameStartedLoadingEvent }) => void): void;
@@ -3696,6 +3979,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when frame has stopped loading.
+         * @experimental
          */
         onFrameStoppedLoading(listener: (event: { params: Protocol.Page.FrameStoppedLoadingEvent }) => void): void;
         offFrameStoppedLoading(listener: (event: { params: Protocol.Page.FrameStoppedLoadingEvent }) => void): void;
@@ -3704,6 +3988,8 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Fired when page is about to start a download.
          * Deprecated. Use Browser.downloadWillBegin instead.
+         * @deprecated
+         * @experimental
          */
         onDownloadWillBegin(listener: (event: { params: Protocol.Page.DownloadWillBeginEvent }) => void): void;
         offDownloadWillBegin(listener: (event: { params: Protocol.Page.DownloadWillBeginEvent }) => void): void;
@@ -3712,6 +3998,8 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Fired when download makes progress. Last call has |done| == true.
          * Deprecated. Use Browser.downloadProgress instead.
+         * @deprecated
+         * @experimental
          */
         onDownloadProgress(listener: (event: { params: Protocol.Page.DownloadProgressEvent }) => void): void;
         offDownloadProgress(listener: (event: { params: Protocol.Page.DownloadProgressEvent }) => void): void;
@@ -3760,6 +4048,7 @@ export namespace ProtocolTestsProxyApi {
          * not assume any ordering with the Page.frameNavigated event. This event is fired only for
          * main-frame history navigation where the document changes (non-same-document navigations),
          * when bfcache navigation fails.
+         * @experimental
          */
         onBackForwardCacheNotUsed(listener: (event: { params: Protocol.Page.BackForwardCacheNotUsedEvent }) => void): void;
         offBackForwardCacheNotUsed(listener: (event: { params: Protocol.Page.BackForwardCacheNotUsedEvent }) => void): void;
@@ -3771,6 +4060,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when same-document navigation happens, e.g. due to history API usage or anchor navigation.
+         * @experimental
          */
         onNavigatedWithinDocument(listener: (event: { params: Protocol.Page.NavigatedWithinDocumentEvent }) => void): void;
         offNavigatedWithinDocument(listener: (event: { params: Protocol.Page.NavigatedWithinDocumentEvent }) => void): void;
@@ -3778,6 +4068,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Compressed image data requested by the `startScreencast`.
+         * @experimental
          */
         onScreencastFrame(listener: (event: { params: Protocol.Page.ScreencastFrameEvent }) => void): void;
         offScreencastFrame(listener: (event: { params: Protocol.Page.ScreencastFrameEvent }) => void): void;
@@ -3785,6 +4076,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Fired when the page with currently enabled screencast was shown or hidden `.
+         * @experimental
          */
         onScreencastVisibilityChanged(listener: (event: { params: Protocol.Page.ScreencastVisibilityChangedEvent }) => void): void;
         offScreencastVisibilityChanged(listener: (event: { params: Protocol.Page.ScreencastVisibilityChangedEvent }) => void): void;
@@ -3801,6 +4093,7 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Issued for every compilation cache generated. Is only available
          * if Page.setGenerateCompilationCache is enabled.
+         * @experimental
          */
         onCompilationCacheProduced(listener: (event: { params: Protocol.Page.CompilationCacheProducedEvent }) => void): void;
         offCompilationCacheProduced(listener: (event: { params: Protocol.Page.CompilationCacheProducedEvent }) => void): void;
@@ -3823,6 +4116,8 @@ export namespace ProtocolTestsProxyApi {
          * Sets time domain to use for collecting and reporting duration metrics.
          * Note that this must be called before enabling metrics collection. Calling
          * this method while metrics collection is enabled returns an error.
+         * @deprecated
+         * @experimental
          */
         setTimeDomain(params: Protocol.Performance.SetTimeDomainRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -3874,12 +4169,14 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Handles a certificate error that fired a certificateError event.
+         * @deprecated
          */
         handleCertificateError(params: Protocol.Security.HandleCertificateErrorRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Enable/disable overriding certificate errors. If enabled, all certificate error events need to
          * be handled by the DevTools client and should be answered with `handleCertificateError` commands.
+         * @deprecated
          */
         setOverrideCertificateErrors(params: Protocol.Security.SetOverrideCertificateErrorsRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -3888,6 +4185,7 @@ export namespace ProtocolTestsProxyApi {
          * handled with the `handleCertificateError` command. Note: this event does not fire if the
          * certificate error has been allowed internally. Only one client per target should override
          * certificate errors at the same time.
+         * @deprecated
          */
         onCertificateError(listener: (event: { params: Protocol.Security.CertificateErrorEvent }) => void): void;
         offCertificateError(listener: (event: { params: Protocol.Security.CertificateErrorEvent }) => void): void;
@@ -3895,6 +4193,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * The security state of the page changed.
+         * @experimental
          */
         onVisibleSecurityStateChanged(listener: (event: { params: Protocol.Security.VisibleSecurityStateChangedEvent }) => void): void;
         offVisibleSecurityStateChanged(listener: (event: { params: Protocol.Security.VisibleSecurityStateChangedEvent }) => void): void;
@@ -3902,6 +4201,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * The security state of the page changed. No longer being sent.
+         * @deprecated
          */
         onSecurityStateChanged(listener: (event: { params: Protocol.Security.SecurityStateChangedEvent }) => void): void;
         offSecurityStateChanged(listener: (event: { params: Protocol.Security.SecurityStateChangedEvent }) => void): void;
@@ -3986,6 +4286,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Override quota for the specified origin
+         * @experimental
          */
         overrideQuotaForOrigin(params: Protocol.Storage.OverrideQuotaForOriginRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -4032,100 +4333,119 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Returns the number of stored Trust Tokens per issuer for the
          * current browsing context.
+         * @experimental
          */
         getTrustTokens(): Promise<{id: number, result: Protocol.Storage.GetTrustTokensResponse, sessionId: string}>;
 
         /**
          * Removes all Trust Tokens issued by the provided issuerOrigin.
          * Leaves other stored data, including the issuer's Redemption Records, intact.
+         * @experimental
          */
         clearTrustTokens(params: Protocol.Storage.ClearTrustTokensRequest): Promise<{id: number, result: Protocol.Storage.ClearTrustTokensResponse, sessionId: string}>;
 
         /**
          * Gets details for a named interest group.
+         * @experimental
          */
         getInterestGroupDetails(params: Protocol.Storage.GetInterestGroupDetailsRequest): Promise<{id: number, result: Protocol.Storage.GetInterestGroupDetailsResponse, sessionId: string}>;
 
         /**
          * Enables/Disables issuing of interestGroupAccessed events.
+         * @experimental
          */
         setInterestGroupTracking(params: Protocol.Storage.SetInterestGroupTrackingRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Enables/Disables issuing of interestGroupAuctionEventOccurred and
          * interestGroupAuctionNetworkRequestCreated.
+         * @experimental
          */
         setInterestGroupAuctionTracking(params: Protocol.Storage.SetInterestGroupAuctionTrackingRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Gets metadata for an origin's shared storage.
+         * @experimental
          */
         getSharedStorageMetadata(params: Protocol.Storage.GetSharedStorageMetadataRequest): Promise<{id: number, result: Protocol.Storage.GetSharedStorageMetadataResponse, sessionId: string}>;
 
         /**
          * Gets the entries in an given origin's shared storage.
+         * @experimental
          */
         getSharedStorageEntries(params: Protocol.Storage.GetSharedStorageEntriesRequest): Promise<{id: number, result: Protocol.Storage.GetSharedStorageEntriesResponse, sessionId: string}>;
 
         /**
          * Sets entry with `key` and `value` for a given origin's shared storage.
+         * @experimental
          */
         setSharedStorageEntry(params: Protocol.Storage.SetSharedStorageEntryRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Deletes entry for `key` (if it exists) for a given origin's shared storage.
+         * @experimental
          */
         deleteSharedStorageEntry(params: Protocol.Storage.DeleteSharedStorageEntryRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Clears all entries for a given origin's shared storage.
+         * @experimental
          */
         clearSharedStorageEntries(params: Protocol.Storage.ClearSharedStorageEntriesRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Resets the budget for `ownerOrigin` by clearing all budget withdrawals.
+         * @experimental
          */
         resetSharedStorageBudget(params: Protocol.Storage.ResetSharedStorageBudgetRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Enables/disables issuing of sharedStorageAccessed events.
+         * @experimental
          */
         setSharedStorageTracking(params: Protocol.Storage.SetSharedStorageTrackingRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Set tracking for a storage key's buckets.
+         * @experimental
          */
         setStorageBucketTracking(params: Protocol.Storage.SetStorageBucketTrackingRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Deletes the Storage Bucket with the given storage key and bucket name.
+         * @experimental
          */
         deleteStorageBucket(params: Protocol.Storage.DeleteStorageBucketRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Deletes state for sites identified as potential bounce trackers, immediately.
+         * @experimental
          */
         runBounceTrackingMitigations(): Promise<{id: number, result: Protocol.Storage.RunBounceTrackingMitigationsResponse, sessionId: string}>;
 
         /**
          * https://wicg.github.io/attribution-reporting-api/
+         * @experimental
          */
         setAttributionReportingLocalTestingMode(params: Protocol.Storage.SetAttributionReportingLocalTestingModeRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Enables/disables issuing of Attribution Reporting events.
+         * @experimental
          */
         setAttributionReportingTracking(params: Protocol.Storage.SetAttributionReportingTrackingRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Sends all pending Attribution Reports immediately, regardless of their
          * scheduled report time.
+         * @experimental
          */
         sendPendingAttributionReports(): Promise<{id: number, result: Protocol.Storage.SendPendingAttributionReportsResponse, sessionId: string}>;
 
         /**
          * Returns the effective Related Website Sets in use by this profile for the browser
          * session. The effective Related Website Sets will not change during a browser session.
+         * @experimental
          */
         getRelatedWebsiteSets(): Promise<{id: number, result: Protocol.Storage.GetRelatedWebsiteSetsResponse, sessionId: string}>;
 
@@ -4133,6 +4453,7 @@ export namespace ProtocolTestsProxyApi {
          * Returns the list of URLs from a page and its embedded resources that match
          * existing grace period URL pattern rules.
          * https://developers.google.com/privacy-sandbox/cookies/temporary-exceptions/grace-period
+         * @experimental
          */
         getAffectedUrlsForThirdPartyCookieMetadata(params: Protocol.Storage.GetAffectedUrlsForThirdPartyCookieMetadataRequest): Promise<{id: number, result: Protocol.Storage.GetAffectedUrlsForThirdPartyCookieMetadataResponse, sessionId: string}>;
 
@@ -4216,18 +4537,30 @@ export namespace ProtocolTestsProxyApi {
         offStorageBucketDeleted(listener: (event: { params: Protocol.Storage.StorageBucketDeletedEvent }) => void): void;
         onceStorageBucketDeleted(eventMatcher?: (event: { params: Protocol.Storage.StorageBucketDeletedEvent }) => boolean): Promise<{ params: Protocol.Storage.StorageBucketDeletedEvent }>;
 
+        /**
+         * @experimental
+         */
         onAttributionReportingSourceRegistered(listener: (event: { params: Protocol.Storage.AttributionReportingSourceRegisteredEvent }) => void): void;
         offAttributionReportingSourceRegistered(listener: (event: { params: Protocol.Storage.AttributionReportingSourceRegisteredEvent }) => void): void;
         onceAttributionReportingSourceRegistered(eventMatcher?: (event: { params: Protocol.Storage.AttributionReportingSourceRegisteredEvent }) => boolean): Promise<{ params: Protocol.Storage.AttributionReportingSourceRegisteredEvent }>;
 
+        /**
+         * @experimental
+         */
         onAttributionReportingTriggerRegistered(listener: (event: { params: Protocol.Storage.AttributionReportingTriggerRegisteredEvent }) => void): void;
         offAttributionReportingTriggerRegistered(listener: (event: { params: Protocol.Storage.AttributionReportingTriggerRegisteredEvent }) => void): void;
         onceAttributionReportingTriggerRegistered(eventMatcher?: (event: { params: Protocol.Storage.AttributionReportingTriggerRegisteredEvent }) => boolean): Promise<{ params: Protocol.Storage.AttributionReportingTriggerRegisteredEvent }>;
 
+        /**
+         * @experimental
+         */
         onAttributionReportingReportSent(listener: (event: { params: Protocol.Storage.AttributionReportingReportSentEvent }) => void): void;
         offAttributionReportingReportSent(listener: (event: { params: Protocol.Storage.AttributionReportingReportSentEvent }) => void): void;
         onceAttributionReportingReportSent(eventMatcher?: (event: { params: Protocol.Storage.AttributionReportingReportSentEvent }) => boolean): Promise<{ params: Protocol.Storage.AttributionReportingReportSentEvent }>;
 
+        /**
+         * @experimental
+         */
         onAttributionReportingVerboseDebugReportSent(listener: (event: { params: Protocol.Storage.AttributionReportingVerboseDebugReportSentEvent }) => void): void;
         offAttributionReportingVerboseDebugReportSent(listener: (event: { params: Protocol.Storage.AttributionReportingVerboseDebugReportSentEvent }) => void): void;
         onceAttributionReportingVerboseDebugReportSent(eventMatcher?: (event: { params: Protocol.Storage.AttributionReportingVerboseDebugReportSentEvent }) => boolean): Promise<{ params: Protocol.Storage.AttributionReportingVerboseDebugReportSentEvent }>;
@@ -4265,6 +4598,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Attaches to the browser target, only uses flat sessionId mode.
+         * @experimental
          */
         attachToBrowserTarget(): Promise<{id: number, result: Protocol.Target.AttachToBrowserTargetResponse, sessionId: string}>;
 
@@ -4282,6 +4616,7 @@ export namespace ProtocolTestsProxyApi {
          * The object has the following API:
          * - `binding.send(json)` - a method to send messages over the remote debugging protocol
          * - `binding.onmessage = json => handleMessage(json)` - a callback that will be called for the protocol notifications and command responses.
+         * @experimental
          */
         exposeDevToolsProtocol(params: Protocol.Target.ExposeDevToolsProtocolRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -4314,6 +4649,7 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Returns information about a target.
+         * @experimental
          */
         getTargetInfo(params: Protocol.Target.GetTargetInfoRequest): Promise<{id: number, result: Protocol.Target.GetTargetInfoResponse, sessionId: string}>;
 
@@ -4326,6 +4662,7 @@ export namespace ProtocolTestsProxyApi {
          * Sends protocol message over session with given id.
          * Consider using flat mode instead; see commands attachToTarget, setAutoAttach,
          * and crbug.com/991325.
+         * @deprecated
          */
         sendMessageToTarget(params: Protocol.Target.SendMessageToTargetRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -4347,6 +4684,7 @@ export namespace ProtocolTestsProxyApi {
          * through `attachedToTarget`. The specified target is also auto-attached.
          * This cancels the effect of any previous `setAutoAttach` and is also cancelled by subsequent
          * `setAutoAttach`. Only available at the Browser target.
+         * @experimental
          */
         autoAttachRelated(params: Protocol.Target.AutoAttachRelatedRequest): Promise<{id: number, result: void, sessionId: string}>;
 
@@ -4359,11 +4697,13 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Enables target discovery for the specified locations, when `setDiscoverTargets` was set to
          * `true`.
+         * @experimental
          */
         setRemoteLocations(params: Protocol.Target.SetRemoteLocationsRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Issued when attached to target because of auto-attach or `attachToTarget` command.
+         * @experimental
          */
         onAttachedToTarget(listener: (event: { params: Protocol.Target.AttachedToTargetEvent }) => void): void;
         offAttachedToTarget(listener: (event: { params: Protocol.Target.AttachedToTargetEvent }) => void): void;
@@ -4372,6 +4712,7 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Issued when detached from target for any reason (including `detachFromTarget` command). Can be
          * issued multiple times per target if multiple sessions have been attached to it.
+         * @experimental
          */
         onDetachedFromTarget(listener: (event: { params: Protocol.Target.DetachedFromTargetEvent }) => void): void;
         offDetachedFromTarget(listener: (event: { params: Protocol.Target.DetachedFromTargetEvent }) => void): void;
@@ -4444,16 +4785,19 @@ export namespace ProtocolTestsProxyApi {
 
         /**
          * Gets supported tracing categories.
+         * @experimental
          */
         getCategories(): Promise<{id: number, result: Protocol.Tracing.GetCategoriesResponse, sessionId: string}>;
 
         /**
          * Record a clock sync marker in the trace.
+         * @experimental
          */
         recordClockSyncMarker(params: Protocol.Tracing.RecordClockSyncMarkerRequest): Promise<{id: number, result: void, sessionId: string}>;
 
         /**
          * Request a global memory dump.
+         * @experimental
          */
         requestMemoryDump(params: Protocol.Tracing.RequestMemoryDumpRequest): Promise<{id: number, result: Protocol.Tracing.RequestMemoryDumpResponse, sessionId: string}>;
 
@@ -4462,6 +4806,9 @@ export namespace ProtocolTestsProxyApi {
          */
         start(params: Protocol.Tracing.StartRequest): Promise<{id: number, result: void, sessionId: string}>;
 
+        /**
+         * @experimental
+         */
         onBufferUsage(listener: (event: { params: Protocol.Tracing.BufferUsageEvent }) => void): void;
         offBufferUsage(listener: (event: { params: Protocol.Tracing.BufferUsageEvent }) => void): void;
         onceBufferUsage(eventMatcher?: (event: { params: Protocol.Tracing.BufferUsageEvent }) => boolean): Promise<{ params: Protocol.Tracing.BufferUsageEvent }>;
@@ -4469,6 +4816,7 @@ export namespace ProtocolTestsProxyApi {
         /**
          * Contains a bucket of collected trace events. When tracing is stopped collected events will be
          * sent as a sequence of dataCollected events followed by tracingComplete event.
+         * @experimental
          */
         onDataCollected(listener: (event: { params: Protocol.Tracing.DataCollectedEvent }) => void): void;
         offDataCollected(listener: (event: { params: Protocol.Tracing.DataCollectedEvent }) => void): void;
@@ -4520,6 +4868,7 @@ export namespace ProtocolTestsProxyApi {
          * Continues loading of the paused response, optionally modifying the
          * response headers. If either responseCode or headers are modified, all of them
          * must be present.
+         * @experimental
          */
         continueResponse(params: Protocol.Fetch.ContinueResponseRequest): Promise<{id: number, result: void, sessionId: string}>;
 

--- a/types/protocol.d.ts
+++ b/types/protocol.d.ts
@@ -12,6 +12,7 @@ export namespace Protocol {
 
     /**
      * This domain is deprecated - use Runtime or Log instead.
+     * @deprecated
      */
     export namespace Console {
 
@@ -42,11 +43,11 @@ export namespace Protocol {
          */
         export interface ConsoleMessage {
             /**
-             * Message source. (ConsoleMessageSource enum)
+             * Message source.
              */
             source: ('xml' | 'javascript' | 'network' | 'console-api' | 'storage' | 'appcache' | 'rendering' | 'security' | 'other' | 'deprecation' | 'worker');
             /**
-             * Message severity. (ConsoleMessageLevel enum)
+             * Message severity.
              */
             level: ('log' | 'warning' | 'error' | 'debug' | 'info');
             /**
@@ -114,6 +115,7 @@ export namespace Protocol {
 
         /**
          * Location in the source code.
+         * @experimental
          */
         export interface ScriptPosition {
             lineNumber: integer;
@@ -122,6 +124,7 @@ export namespace Protocol {
 
         /**
          * Location range within one script.
+         * @experimental
          */
         export interface LocationRange {
             scriptId: Runtime.ScriptId;
@@ -153,6 +156,7 @@ export namespace Protocol {
              * JavaScript script name or url.
              * Deprecated in favor of using the `location.scriptId` to resolve the URL via a previously
              * sent `Debugger.scriptParsed` event.
+             * @deprecated
              */
             url: string;
             /**
@@ -172,6 +176,7 @@ export namespace Protocol {
              * can be restarted or not. Note that a `true` value here does not
              * guarantee that Debugger#restartFrame with this CallFrameId will be
              * successful, but it is very likely.
+             * @experimental
              */
             canBeRestarted?: boolean;
         }
@@ -194,7 +199,7 @@ export namespace Protocol {
          */
         export interface Scope {
             /**
-             * Scope type. (ScopeType enum)
+             * Scope type.
              */
             type: ('global' | 'local' | 'with' | 'closure' | 'catch' | 'block' | 'script' | 'eval' | 'module' | 'wasm-expression-stack');
             /**
@@ -247,12 +252,12 @@ export namespace Protocol {
              * Column number in the script (0-based).
              */
             columnNumber?: integer;
-            /**
-             *  (BreakLocationType enum)
-             */
             type?: ('debuggerStatement' | 'call' | 'return');
         }
 
+        /**
+         * @experimental
+         */
         export interface WasmDisassemblyChunk {
             /**
              * The next chunk of disassembled lines.
@@ -280,7 +285,7 @@ export namespace Protocol {
          */
         export interface DebugSymbols {
             /**
-             * Type of the debug symbols. (DebugSymbolsType enum)
+             * Type of the debug symbols.
              */
             type: ('SourceMap' | 'EmbeddedDWARF' | 'ExternalDWARF');
             /**
@@ -310,9 +315,6 @@ export namespace Protocol {
              * Location to continue to.
              */
             location: Location;
-            /**
-             *  (ContinueToLocationRequestTargetCallFrames enum)
-             */
             targetCallFrames?: ('any' | 'current');
         }
 
@@ -320,6 +322,7 @@ export namespace Protocol {
             /**
              * The maximum size in bytes of collected scripts (not referenced by other heap objects)
              * the debugger can hold. Puts no limit if parameter is omitted.
+             * @experimental
              */
             maxScriptsCacheSize?: number;
         }
@@ -327,6 +330,7 @@ export namespace Protocol {
         export interface EnableResponse {
             /**
              * Unique identifier of the debugger.
+             * @experimental
              */
             debuggerId: Runtime.UniqueDebuggerId;
         }
@@ -361,6 +365,7 @@ export namespace Protocol {
             returnByValue?: boolean;
             /**
              * Whether preview should be generated for the result.
+             * @experimental
              */
             generatePreview?: boolean;
             /**
@@ -369,6 +374,7 @@ export namespace Protocol {
             throwOnSideEffect?: boolean;
             /**
              * Terminate execution after timing out (number of milliseconds).
+             * @experimental
              */
             timeout?: Runtime.TimeDelta;
         }
@@ -508,7 +514,8 @@ export namespace Protocol {
             callFrameId: CallFrameId;
             /**
              * The `mode` parameter must be present and set to 'StepInto', otherwise
-             * `restartFrame` will error out. (RestartFrameRequestMode enum)
+             * `restartFrame` will error out.
+             * @experimental
              */
             mode?: ('StepInto');
         }
@@ -516,14 +523,17 @@ export namespace Protocol {
         export interface RestartFrameResponse {
             /**
              * New stack trace.
+             * @deprecated
              */
             callFrames: CallFrame[];
             /**
              * Async stack trace, if any.
+             * @deprecated
              */
             asyncStackTrace?: Runtime.StackTrace;
             /**
              * Async stack trace, if any.
+             * @deprecated
              */
             asyncStackTraceId?: Runtime.StackTraceId;
         }
@@ -629,7 +639,7 @@ export namespace Protocol {
 
         export interface SetInstrumentationBreakpointRequest {
             /**
-             * Instrumentation name. (SetInstrumentationBreakpointRequestInstrumentation enum)
+             * Instrumentation name.
              */
             instrumentation: ('beforeScriptExecution' | 'beforeScriptWithSourceMapExecution');
         }
@@ -716,7 +726,7 @@ export namespace Protocol {
 
         export interface SetPauseOnExceptionsRequest {
             /**
-             * Pause on exceptions mode. (SetPauseOnExceptionsRequestState enum)
+             * Pause on exceptions mode.
              */
             state: ('none' | 'caught' | 'uncaught' | 'all');
         }
@@ -753,6 +763,7 @@ export namespace Protocol {
             /**
              * If true, then `scriptSource` is allowed to change the function on top of the stack
              * as long as the top-most stack frame is the only activation of that function.
+             * @experimental
              */
             allowTopFrameEditing?: boolean;
         }
@@ -760,24 +771,29 @@ export namespace Protocol {
         export interface SetScriptSourceResponse {
             /**
              * New stack trace in case editing has happened while VM was stopped.
+             * @deprecated
              */
             callFrames?: CallFrame[];
             /**
              * Whether current call stack  was modified after applying the changes.
+             * @deprecated
              */
             stackChanged?: boolean;
             /**
              * Async stack trace, if any.
+             * @deprecated
              */
             asyncStackTrace?: Runtime.StackTrace;
             /**
              * Async stack trace, if any.
+             * @deprecated
              */
             asyncStackTraceId?: Runtime.StackTraceId;
             /**
              * Whether the operation was successful or not. Only `Ok` denotes a
              * successful live edit while the other enum variants denote why
-             * the live edit failed. (SetScriptSourceResponseStatus enum)
+             * the live edit failed.
+             * @experimental
              */
             status: ('Ok' | 'CompileError' | 'BlockedByActiveGenerator' | 'BlockedByActiveFunction' | 'BlockedByTopLevelEsModuleChange');
             /**
@@ -817,10 +833,12 @@ export namespace Protocol {
             /**
              * Debugger will pause on the execution of the first async task which was scheduled
              * before next pause.
+             * @experimental
              */
             breakOnAsyncCall?: boolean;
             /**
              * The skipList specifies location ranges that should be skipped on step into.
+             * @experimental
              */
             skipList?: LocationRange[];
         }
@@ -828,6 +846,7 @@ export namespace Protocol {
         export interface StepOverRequest {
             /**
              * The skipList specifies location ranges that should be skipped on step over.
+             * @experimental
              */
             skipList?: LocationRange[];
         }
@@ -835,6 +854,7 @@ export namespace Protocol {
         /**
          * Fired when breakpoint is resolved to an actual script and location.
          * Deprecated in favor of `resolvedBreakpoints` in the `scriptParsed` event.
+         * @deprecated
          */
         export interface BreakpointResolvedEvent {
             /**
@@ -872,7 +892,7 @@ export namespace Protocol {
              */
             callFrames: CallFrame[];
             /**
-             * Pause reason. (PausedEventReason enum)
+             * Pause reason.
              */
             reason: ('ambiguous' | 'assert' | 'CSPViolation' | 'debugCommand' | 'DOM' | 'EventListener' | 'exception' | 'instrumentation' | 'OOM' | 'other' | 'promiseRejection' | 'XHR' | 'step');
             /**
@@ -889,10 +909,13 @@ export namespace Protocol {
             asyncStackTrace?: Runtime.StackTrace;
             /**
              * Async stack trace, if any.
+             * @experimental
              */
             asyncStackTraceId?: Runtime.StackTraceId;
             /**
              * Never present, will be removed.
+             * @deprecated
+             * @experimental
              */
             asyncCallStackTraceId?: Runtime.StackTraceId;
         }
@@ -959,18 +982,22 @@ export namespace Protocol {
             length?: integer;
             /**
              * JavaScript top stack frame of where the script parsed event was triggered if available.
+             * @experimental
              */
             stackTrace?: Runtime.StackTrace;
             /**
              * If the scriptLanguage is WebAssembly, the code section offset in the module.
+             * @experimental
              */
             codeOffset?: integer;
             /**
              * The language of the script.
+             * @experimental
              */
             scriptLanguage?: Debugger.ScriptLanguage;
             /**
              * The name the embedder supplied for this script.
+             * @experimental
              */
             embedderName?: string;
         }
@@ -1022,6 +1049,7 @@ export namespace Protocol {
             executionContextAuxData?: any;
             /**
              * True, if this script is generated as a result of the live edit operation.
+             * @experimental
              */
             isLiveEdit?: boolean;
             /**
@@ -1042,33 +1070,42 @@ export namespace Protocol {
             length?: integer;
             /**
              * JavaScript top stack frame of where the script parsed event was triggered if available.
+             * @experimental
              */
             stackTrace?: Runtime.StackTrace;
             /**
              * If the scriptLanguage is WebAssembly, the code section offset in the module.
+             * @experimental
              */
             codeOffset?: integer;
             /**
              * The language of the script.
+             * @experimental
              */
             scriptLanguage?: Debugger.ScriptLanguage;
             /**
              * If the scriptLanguage is WebAssembly, the source of debug symbols for the module.
+             * @experimental
              */
             debugSymbols?: Debugger.DebugSymbols[];
             /**
              * The name the embedder supplied for this script.
+             * @experimental
              */
             embedderName?: string;
             /**
              * The list of set breakpoints in this script if calls to `setBreakpointByUrl`
              * matches this script's URL or hash. Clients that use this list can ignore the
              * `breakpointResolved` event. They are equivalent.
+             * @experimental
              */
             resolvedBreakpoints?: ResolvedBreakpoint[];
         }
     }
 
+    /**
+     * @experimental
+     */
     export namespace HeapProfiler {
 
         /**
@@ -1215,6 +1252,7 @@ export namespace Protocol {
             reportProgress?: boolean;
             /**
              * Deprecated in favor of `exposeInternals`.
+             * @deprecated
              */
             treatGlobalObjectsAsRoots?: boolean;
             /**
@@ -1223,6 +1261,7 @@ export namespace Protocol {
             captureNumericValue?: boolean;
             /**
              * If true, exposes internals of the snapshot.
+             * @experimental
              */
             exposeInternals?: boolean;
         }
@@ -1235,6 +1274,7 @@ export namespace Protocol {
             /**
              * If true, a raw snapshot without artificial roots will be generated.
              * Deprecated in favor of `exposeInternals`.
+             * @deprecated
              */
             treatGlobalObjectsAsRoots?: boolean;
             /**
@@ -1243,6 +1283,7 @@ export namespace Protocol {
             captureNumericValue?: boolean;
             /**
              * If true, exposes internals of the snapshot.
+             * @experimental
              */
             exposeInternals?: boolean;
         }
@@ -1495,6 +1536,7 @@ export namespace Protocol {
          * `takePreciseCoverage` for the current isolate. May only be sent if precise code
          * coverage has been started. This event can be trigged by the embedder to, for example,
          * trigger collection of coverage data immediately at a certain point in time.
+         * @experimental
          */
         export interface PreciseCoverageDeltaUpdateEvent {
             /**
@@ -1536,9 +1578,6 @@ export namespace Protocol {
          * Represents options for serialization. Overrides `generatePreview` and `returnByValue`.
          */
         export interface SerializationOptions {
-            /**
-             *  (SerializationOptionsSerialization enum)
-             */
             serialization: ('deep' | 'json' | 'idOnly');
             /**
              * Deep serialization depth. Default is full depth. Respected only in `deep` serialization mode.
@@ -1583,9 +1622,6 @@ export namespace Protocol {
          * Represents deep serialized value.
          */
         export interface DeepSerializedValue {
-            /**
-             *  (DeepSerializedValueType enum)
-             */
             type: ('undefined' | 'null' | 'string' | 'number' | 'boolean' | 'bigint' | 'regexp' | 'date' | 'symbol' | 'array' | 'object' | 'function' | 'map' | 'set' | 'weakmap' | 'weakset' | 'error' | 'proxy' | 'promise' | 'typedarray' | 'arraybuffer' | 'node' | 'window' | 'generator');
             value?: any;
             objectId?: string;
@@ -1646,13 +1682,13 @@ export namespace Protocol {
          */
         export interface RemoteObject {
             /**
-             * Object type. (RemoteObjectType enum)
+             * Object type.
              */
             type: ('object' | 'function' | 'undefined' | 'string' | 'number' | 'boolean' | 'symbol' | 'bigint');
             /**
              * Object subtype hint. Specified for `object` type values only.
              * NOTE: If you change anything here, make sure to also update
-             * `subtype` in `ObjectPreview` and `PropertyPreview` below. (RemoteObjectSubtype enum)
+             * `subtype` in `ObjectPreview` and `PropertyPreview` below.
              */
             subtype?: ('array' | 'null' | 'node' | 'regexp' | 'date' | 'map' | 'set' | 'weakmap' | 'weakset' | 'iterator' | 'generator' | 'error' | 'proxy' | 'promise' | 'typedarray' | 'arraybuffer' | 'dataview' | 'webassemblymemory' | 'wasmvalue');
             /**
@@ -1674,6 +1710,7 @@ export namespace Protocol {
             description?: string;
             /**
              * Deep serialized value.
+             * @experimental
              */
             deepSerializedValue?: DeepSerializedValue;
             /**
@@ -1682,11 +1719,18 @@ export namespace Protocol {
             objectId?: RemoteObjectId;
             /**
              * Preview containing abbreviated property values. Specified for `object` type values only.
+             * @experimental
              */
             preview?: ObjectPreview;
+            /**
+             * @experimental
+             */
             customPreview?: CustomPreview;
         }
 
+        /**
+         * @experimental
+         */
         export interface CustomPreview {
             /**
              * The JSON-stringified result of formatter.header(object, config) call.
@@ -1736,14 +1780,15 @@ export namespace Protocol {
 
         /**
          * Object containing abbreviated remote object value.
+         * @experimental
          */
         export interface ObjectPreview {
             /**
-             * Object type. (ObjectPreviewType enum)
+             * Object type.
              */
             type: ('object' | 'function' | 'undefined' | 'string' | 'number' | 'boolean' | 'symbol' | 'bigint');
             /**
-             * Object subtype hint. Specified for `object` type values only. (ObjectPreviewSubtype enum)
+             * Object subtype hint. Specified for `object` type values only.
              */
             subtype?: ('array' | 'null' | 'node' | 'regexp' | 'date' | 'map' | 'set' | 'weakmap' | 'weakset' | 'iterator' | 'generator' | 'error' | 'proxy' | 'promise' | 'typedarray' | 'arraybuffer' | 'dataview' | 'webassemblymemory' | 'wasmvalue');
             /**
@@ -1798,13 +1843,16 @@ export namespace Protocol {
             Wasmvalue = 'wasmvalue',
         }
 
+        /**
+         * @experimental
+         */
         export interface PropertyPreview {
             /**
              * Property name.
              */
             name: string;
             /**
-             * Object type. Accessor means that the property itself is an accessor property. (PropertyPreviewType enum)
+             * Object type. Accessor means that the property itself is an accessor property.
              */
             type: ('object' | 'function' | 'undefined' | 'string' | 'number' | 'boolean' | 'symbol' | 'accessor' | 'bigint');
             /**
@@ -1816,11 +1864,14 @@ export namespace Protocol {
              */
             valuePreview?: ObjectPreview;
             /**
-             * Object subtype hint. Specified for `object` type values only. (PropertyPreviewSubtype enum)
+             * Object subtype hint. Specified for `object` type values only.
              */
             subtype?: ('array' | 'null' | 'node' | 'regexp' | 'date' | 'map' | 'set' | 'weakmap' | 'weakset' | 'iterator' | 'generator' | 'error' | 'proxy' | 'promise' | 'typedarray' | 'arraybuffer' | 'dataview' | 'webassemblymemory' | 'wasmvalue');
         }
 
+        /**
+         * @experimental
+         */
         export interface EntryPreview {
             /**
              * Preview of the key. Specified for map-like collection entries.
@@ -1898,6 +1949,7 @@ export namespace Protocol {
 
         /**
          * Object private field descriptor.
+         * @experimental
          */
         export interface PrivatePropertyDescriptor {
             /**
@@ -1965,6 +2017,7 @@ export namespace Protocol {
              * A system-unique execution context identifier. Unlike the id, this is unique across
              * multiple processes, so can be reliably used to identify specific context while backend
              * performs a cross-process navigation.
+             * @experimental
              */
             uniqueId: string;
             /**
@@ -2018,6 +2071,7 @@ export namespace Protocol {
              * Dictionary with entries of meta data that the client associated
              * with this exception, such as information about associated network
              * requests, etc.
+             * @experimental
              */
             exceptionMetaData?: any;
         }
@@ -2077,18 +2131,21 @@ export namespace Protocol {
             parent?: StackTrace;
             /**
              * Asynchronous JavaScript stack trace that preceded this stack, if available.
+             * @experimental
              */
             parentId?: StackTraceId;
         }
 
         /**
          * Unique identifier of current debugger.
+         * @experimental
          */
         export type UniqueDebuggerId = string;
 
         /**
          * If `debuggerId` is set stack trace comes from another debugger and can be resolved there. This
          * allows to track cross-debugger calls. See `Runtime.StackTrace` and `Debugger.paused` for usages.
+         * @experimental
          */
         export interface StackTraceId {
             id: string;
@@ -2148,6 +2205,7 @@ export namespace Protocol {
             returnByValue?: boolean;
             /**
              * Whether preview should be generated for the result.
+             * @experimental
              */
             generatePreview?: boolean;
             /**
@@ -2171,6 +2229,7 @@ export namespace Protocol {
             objectGroup?: string;
             /**
              * Whether to throw an exception if side effect cannot be ruled out during evaluation.
+             * @experimental
              */
             throwOnSideEffect?: boolean;
             /**
@@ -2180,11 +2239,13 @@ export namespace Protocol {
              * in context different than intended (e.g. as a result of navigation across process
              * boundaries).
              * This is mutually exclusive with `executionContextId`.
+             * @experimental
              */
             uniqueContextId?: string;
             /**
              * Specifies the result serialization. If provided, overrides
              * `generatePreview` and `returnByValue`.
+             * @experimental
              */
             serializationOptions?: SerializationOptions;
         }
@@ -2263,6 +2324,7 @@ export namespace Protocol {
             returnByValue?: boolean;
             /**
              * Whether preview should be generated for the result.
+             * @experimental
              */
             generatePreview?: boolean;
             /**
@@ -2277,20 +2339,24 @@ export namespace Protocol {
             /**
              * Whether to throw an exception if side effect cannot be ruled out during evaluation.
              * This implies `disableBreaks` below.
+             * @experimental
              */
             throwOnSideEffect?: boolean;
             /**
              * Terminate execution after timing out (number of milliseconds).
+             * @experimental
              */
             timeout?: TimeDelta;
             /**
              * Disable breakpoints during execution.
+             * @experimental
              */
             disableBreaks?: boolean;
             /**
              * Setting this flag to true enables `let` re-declaration and top-level `await`.
              * Note that `let` variables can only be re-declared if they originate from
              * `replMode` themselves.
+             * @experimental
              */
             replMode?: boolean;
             /**
@@ -2298,6 +2364,7 @@ export namespace Protocol {
              * which includes eval(), Function(), setTimeout() and setInterval()
              * when called with non-callable arguments. This flag bypasses CSP for this
              * evaluation and allows unsafe-eval. Defaults to true.
+             * @experimental
              */
             allowUnsafeEvalBlockedByCSP?: boolean;
             /**
@@ -2307,11 +2374,13 @@ export namespace Protocol {
              * in context different than intended (e.g. as a result of navigation across process
              * boundaries).
              * This is mutually exclusive with `contextId`.
+             * @experimental
              */
             uniqueContextId?: string;
             /**
              * Specifies the result serialization. If provided, overrides
              * `generatePreview` and `returnByValue`.
+             * @experimental
              */
             serializationOptions?: SerializationOptions;
         }
@@ -2366,14 +2435,17 @@ export namespace Protocol {
             /**
              * If true, returns accessor properties (with getter/setter) only; internal properties are not
              * returned either.
+             * @experimental
              */
             accessorPropertiesOnly?: boolean;
             /**
              * Whether preview should be generated for the results.
+             * @experimental
              */
             generatePreview?: boolean;
             /**
              * If true, returns non-indexed properties only.
+             * @experimental
              */
             nonIndexedPropertiesOnly?: boolean;
         }
@@ -2389,6 +2461,7 @@ export namespace Protocol {
             internalProperties?: InternalPropertyDescriptor[];
             /**
              * Object private properties.
+             * @experimental
              */
             privateProperties?: PrivatePropertyDescriptor[];
             /**
@@ -2515,6 +2588,8 @@ export namespace Protocol {
              * Deprecated in favor of `executionContextName` due to an unclear use case
              * and bugs in implementation (crbug.com/1169639). `executionContextId` will be
              * removed in the future.
+             * @deprecated
+             * @experimental
              */
             executionContextId?: ExecutionContextId;
             /**
@@ -2544,6 +2619,7 @@ export namespace Protocol {
 
         /**
          * Notification is issued every time when binding is called.
+         * @experimental
          */
         export interface BindingCalledEvent {
             name: string;
@@ -2580,7 +2656,7 @@ export namespace Protocol {
          */
         export interface ConsoleAPICalledEvent {
             /**
-             * Type of the call. (ConsoleAPICalledEventType enum)
+             * Type of the call.
              */
             type: ('log' | 'debug' | 'info' | 'error' | 'warning' | 'dir' | 'dirxml' | 'table' | 'trace' | 'clear' | 'startGroup' | 'startGroupCollapsed' | 'endGroup' | 'assert' | 'profile' | 'profileEnd' | 'count' | 'timeEnd');
             /**
@@ -2605,6 +2681,7 @@ export namespace Protocol {
              * Console context descriptor for calls on non-default console context (not console.*):
              * 'anonymous#unique-logger-id' for call on unnamed context, 'name#unique-logger-id' for call
              * on named context.
+             * @experimental
              */
             context?: string;
         }
@@ -2650,10 +2727,12 @@ export namespace Protocol {
         export interface ExecutionContextDestroyedEvent {
             /**
              * Id of the destroyed context
+             * @deprecated
              */
             executionContextId: ExecutionContextId;
             /**
              * Unique Id of the destroyed context
+             * @experimental
              */
             executionContextUniqueId: string;
         }
@@ -2667,6 +2746,7 @@ export namespace Protocol {
             hints: any;
             /**
              * Identifier of the context where the call was made.
+             * @experimental
              */
             executionContextId?: ExecutionContextId;
         }
@@ -2674,6 +2754,7 @@ export namespace Protocol {
 
     /**
      * This domain is deprecated.
+     * @deprecated
      */
     export namespace Schema {
 
@@ -2699,6 +2780,9 @@ export namespace Protocol {
         }
     }
 
+    /**
+     * @experimental
+     */
     export namespace Accessibility {
 
         /**
@@ -3001,6 +3085,7 @@ export namespace Protocol {
         /**
          * The loadComplete event mirrors the load complete event sent by the browser to assistive
          * technology when the web page has finished loading.
+         * @experimental
          */
         export interface LoadCompleteEvent {
             /**
@@ -3011,6 +3096,7 @@ export namespace Protocol {
 
         /**
          * The nodesUpdated event is sent every time a previously requested node has changed the in tree.
+         * @experimental
          */
         export interface NodesUpdatedEvent {
             /**
@@ -3020,6 +3106,9 @@ export namespace Protocol {
         }
     }
 
+    /**
+     * @experimental
+     */
     export namespace Animation {
 
         export const enum AnimationType {
@@ -3064,7 +3153,7 @@ export namespace Protocol {
              */
             currentTime: number;
             /**
-             * Animation type of `Animation`. (AnimationType enum)
+             * Animation type of `Animation`.
              */
             type: ('CSSTransition' | 'CSSAnimation' | 'WebAnimation');
             /**
@@ -3318,6 +3407,7 @@ export namespace Protocol {
 
     /**
      * Audits domain allows investigation of page violations and possible improvements.
+     * @experimental
      */
     export namespace Audits {
 
@@ -3569,6 +3659,9 @@ export namespace Protocol {
             loaderId: Network.LoaderId;
         }
 
+        /**
+         * @deprecated
+         */
         export interface NavigatorUserAgentIssueDetails {
             url: string;
             location?: SourceCodeLocation;
@@ -3789,6 +3882,9 @@ export namespace Protocol {
             attributionReportingIssueDetails?: AttributionReportingIssueDetails;
             quirksModeIssueDetails?: QuirksModeIssueDetails;
             partitioningBlobURLIssueDetails?: PartitioningBlobURLIssueDetails;
+            /**
+             * @deprecated
+             */
             navigatorUserAgentIssueDetails?: NavigatorUserAgentIssueDetails;
             genericIssueDetails?: GenericIssueDetails;
             deprecationIssueDetails?: DeprecationIssueDetails;
@@ -3836,7 +3932,7 @@ export namespace Protocol {
              */
             requestId: Network.RequestId;
             /**
-             * The encoding to use. (GetEncodedResponseRequestEncoding enum)
+             * The encoding to use.
              */
             encoding: ('webp' | 'jpeg' | 'png');
             /**
@@ -3882,6 +3978,7 @@ export namespace Protocol {
 
     /**
      * Defines commands and events for browser extensions.
+     * @experimental
      */
     export namespace Extensions {
 
@@ -3974,6 +4071,7 @@ export namespace Protocol {
 
     /**
      * Defines commands and events for Autofill.
+     * @experimental
      */
     export namespace Autofill {
 
@@ -4118,6 +4216,7 @@ export namespace Protocol {
 
     /**
      * Defines events for background web platform features.
+     * @experimental
      */
     export namespace BackgroundService {
 
@@ -4210,17 +4309,25 @@ export namespace Protocol {
      */
     export namespace Browser {
 
+        /**
+         * @experimental
+         */
         export type BrowserContextID = string;
 
+        /**
+         * @experimental
+         */
         export type WindowID = integer;
 
         /**
          * The state of the browser window.
+         * @experimental
          */
         export type WindowState = ('normal' | 'minimized' | 'maximized' | 'fullscreen');
 
         /**
          * Browser window bounds information
+         * @experimental
          */
         export interface Bounds {
             /**
@@ -4245,13 +4352,20 @@ export namespace Protocol {
             windowState?: WindowState;
         }
 
+        /**
+         * @experimental
+         */
         export type PermissionType = ('ar' | 'audioCapture' | 'automaticFullscreen' | 'backgroundFetch' | 'backgroundSync' | 'cameraPanTiltZoom' | 'capturedSurfaceControl' | 'clipboardReadWrite' | 'clipboardSanitizedWrite' | 'displayCapture' | 'durableStorage' | 'geolocation' | 'handTracking' | 'idleDetection' | 'keyboardLock' | 'localFonts' | 'localNetworkAccess' | 'midi' | 'midiSysex' | 'nfc' | 'notifications' | 'paymentHandler' | 'periodicBackgroundSync' | 'pointerLock' | 'protectedMediaIdentifier' | 'sensors' | 'smartCard' | 'speakerSelection' | 'storageAccess' | 'topLevelStorageAccess' | 'videoCapture' | 'vr' | 'wakeLockScreen' | 'wakeLockSystem' | 'webAppInstallation' | 'webPrinting' | 'windowManagement');
 
+        /**
+         * @experimental
+         */
         export type PermissionSetting = ('granted' | 'denied' | 'prompt');
 
         /**
          * Definition of PermissionDescriptor defined in the Permissions API:
          * https://w3c.github.io/permissions/#dom-permissiondescriptor.
+         * @experimental
          */
         export interface PermissionDescriptor {
             /**
@@ -4284,11 +4398,13 @@ export namespace Protocol {
 
         /**
          * Browser command ids used by executeBrowserCommand.
+         * @experimental
          */
         export type BrowserCommandId = ('openTabSearch' | 'closeTabSearch' | 'openGlic');
 
         /**
          * Chrome histogram bucket.
+         * @experimental
          */
         export interface Bucket {
             /**
@@ -4307,6 +4423,7 @@ export namespace Protocol {
 
         /**
          * Chrome histogram.
+         * @experimental
          */
         export interface Histogram {
             /**
@@ -4327,6 +4444,9 @@ export namespace Protocol {
             buckets: Bucket[];
         }
 
+        /**
+         * @experimental
+         */
         export type PrivacySandboxAPI = ('BiddingAndAuctionServices' | 'TrustedKeyValue');
 
         export interface SetPermissionRequest {
@@ -4378,7 +4498,7 @@ export namespace Protocol {
             /**
              * Whether to allow all or deny all download requests, or use default Chrome behavior if
              * available (otherwise deny). |allowAndName| allows download and names files according to
-             * their download guids. (SetDownloadBehaviorRequestBehavior enum)
+             * their download guids.
              */
             behavior: ('deny' | 'allow' | 'allowAndName' | 'default');
             /**
@@ -4567,6 +4687,7 @@ export namespace Protocol {
 
         /**
          * Fired when page is about to start a download.
+         * @experimental
          */
         export interface DownloadWillBeginEvent {
             /**
@@ -4595,6 +4716,7 @@ export namespace Protocol {
 
         /**
          * Fired when download makes progress. Last call has |done| == true.
+         * @experimental
          */
         export interface DownloadProgressEvent {
             /**
@@ -4610,13 +4732,14 @@ export namespace Protocol {
              */
             receivedBytes: number;
             /**
-             * Download status. (DownloadProgressEventState enum)
+             * Download status.
              */
             state: ('inProgress' | 'completed' | 'canceled');
             /**
              * If download is "completed", provides the path of the downloaded file.
              * Depending on the platform, it is not guaranteed to be set, nor the file
              * is guaranteed to exist.
+             * @experimental
              */
             filePath?: string;
         }
@@ -4629,6 +4752,7 @@ export namespace Protocol {
      * CSS objects can be loaded using the `get*ForNode()` calls (which accept a DOM node id). A client
      * can also keep track of stylesheets via the `styleSheetAdded`/`styleSheetRemoved` events and
      * subsequently load the required stylesheet contents using the `getStyleSheet[Text]()` methods.
+     * @experimental
      */
     export namespace CSS {
 
@@ -4739,6 +4863,7 @@ export namespace Protocol {
             range?: SourceRange;
             /**
              * Specificity of the selector.
+             * @experimental
              */
             specificity?: Specificity;
         }
@@ -4746,6 +4871,7 @@ export namespace Protocol {
         /**
          * Specificity:
          * https://drafts.csswg.org/selectors/#specificity-rules
+         * @experimental
          */
         export interface Specificity {
             /**
@@ -4858,6 +4984,7 @@ export namespace Protocol {
             endColumn: number;
             /**
              * If the style sheet was loaded from a network resource, this indicates when the resource failed to load
+             * @experimental
              */
             loadingFailed?: boolean;
         }
@@ -4877,6 +5004,7 @@ export namespace Protocol {
             selectorList: SelectorList;
             /**
              * Array of selectors from ancestor style rules, sorted by distance from the current rule.
+             * @experimental
              */
             nestingSelectors?: string[];
             /**
@@ -4895,30 +5023,36 @@ export namespace Protocol {
             /**
              * Container query list array (for rules involving container queries).
              * The array enumerates container queries starting with the innermost one, going outwards.
+             * @experimental
              */
             containerQueries?: CSSContainerQuery[];
             /**
              * @supports CSS at-rule array.
              * The array enumerates @supports at-rules starting with the innermost one, going outwards.
+             * @experimental
              */
             supports?: CSSSupports[];
             /**
              * Cascade layer array. Contains the layer hierarchy that this rule belongs to starting
              * with the innermost layer and going outwards.
+             * @experimental
              */
             layers?: CSSLayer[];
             /**
              * @scope CSS at-rule array.
              * The array enumerates @scope at-rules starting with the innermost one, going outwards.
+             * @experimental
              */
             scopes?: CSSScope[];
             /**
              * The array keeps the types of ancestor CSSRules from the innermost going outwards.
+             * @experimental
              */
             ruleTypes?: CSSRuleType[];
             /**
              * @starting-style CSS at-rule array.
              * The array enumerates @starting-style at-rules starting with the innermost one, going outwards.
+             * @experimental
              */
             startingStyles?: CSSStartingStyle[];
         }
@@ -4926,6 +5060,7 @@ export namespace Protocol {
         /**
          * Enum indicating the type of a CSS rule, used to represent the order of a style rule's ancestors.
          * This list only contains rule types that are collected during the ancestor rule collection.
+         * @experimental
          */
         export type CSSRuleType = ('MediaRule' | 'SupportsRule' | 'ContainerRule' | 'LayerRule' | 'ScopeRule' | 'StyleRule' | 'StartingStyleRule');
 
@@ -5066,6 +5201,7 @@ export namespace Protocol {
             /**
              * Parsed longhand components of this property if it is a shorthand.
              * This field will be empty if the given property is not a shorthand.
+             * @experimental
              */
             longhandProperties?: CSSProperty[];
         }
@@ -5089,7 +5225,7 @@ export namespace Protocol {
              * Source of the media query: "mediaRule" if specified by a @media rule, "importRule" if
              * specified by an @import rule, "linkedSheet" if specified by a "media" attribute in a linked
              * stylesheet's LINK tag, "inlineSheet" if specified by a "media" attribute in an inline
-             * stylesheet's STYLE tag. (CSSMediaSource enum)
+             * stylesheet's STYLE tag.
              */
             source: ('mediaRule' | 'importRule' | 'linkedSheet' | 'inlineSheet');
             /**
@@ -5153,6 +5289,7 @@ export namespace Protocol {
 
         /**
          * CSS container query rule descriptor.
+         * @experimental
          */
         export interface CSSContainerQuery {
             /**
@@ -5192,6 +5329,7 @@ export namespace Protocol {
 
         /**
          * CSS Supports at-rule descriptor.
+         * @experimental
          */
         export interface CSSSupports {
             /**
@@ -5215,6 +5353,7 @@ export namespace Protocol {
 
         /**
          * CSS Scope at-rule descriptor.
+         * @experimental
          */
         export interface CSSScope {
             /**
@@ -5234,6 +5373,7 @@ export namespace Protocol {
 
         /**
          * CSS Layer at-rule descriptor.
+         * @experimental
          */
         export interface CSSLayer {
             /**
@@ -5253,6 +5393,7 @@ export namespace Protocol {
 
         /**
          * CSS Starting Style at-rule descriptor.
+         * @experimental
          */
         export interface CSSStartingStyle {
             /**
@@ -5268,6 +5409,7 @@ export namespace Protocol {
 
         /**
          * CSS Layer data.
+         * @experimental
          */
         export interface CSSLayerData {
             /**
@@ -5632,6 +5774,7 @@ export namespace Protocol {
              * NodeId for the DOM node in whose context custom property declarations for registered properties should be
              * validated. If omitted, declarations in the new rule text can only be validated statically, which may produce
              * incorrect results if the declaration contains a var() for example.
+             * @experimental
              */
             nodeForPropertySyntaxValidation?: DOM.NodeId;
         }
@@ -5864,10 +6007,12 @@ export namespace Protocol {
             cssFontPaletteValuesRule?: CSSFontPaletteValuesRule;
             /**
              * Id of the first parent element that does not have display: contents.
+             * @experimental
              */
             parentLayoutNodeId?: DOM.NodeId;
             /**
              * A list of CSS at-function rules referenced by styles of this node.
+             * @experimental
              */
             cssFunctionRules?: CSSFunctionRule[];
         }
@@ -6052,6 +6197,7 @@ export namespace Protocol {
              * NodeId for the DOM node in whose context custom property declarations for registered properties should be
              * validated. If omitted, declarations in the new rule text can only be validated statically, which may produce
              * incorrect results if the declaration contains a var() for example.
+             * @experimental
              */
             nodeForPropertySyntaxValidation?: DOM.NodeId;
         }
@@ -6120,6 +6266,9 @@ export namespace Protocol {
             styleSheetId: StyleSheetId;
         }
 
+        /**
+         * @experimental
+         */
         export interface ComputedStyleUpdatedEvent {
             /**
              * The node id that has updated computed styles.
@@ -6128,6 +6277,9 @@ export namespace Protocol {
         }
     }
 
+    /**
+     * @experimental
+     */
     export namespace CacheStorage {
 
         /**
@@ -6317,6 +6469,7 @@ export namespace Protocol {
     /**
      * A domain for interacting with Cast, Presentation API, and Remote Playback API
      * functionalities.
+     * @experimental
      */
     export namespace Cast {
 
@@ -6550,6 +6703,7 @@ export namespace Protocol {
              * Deprecated, as the HTML Imports API has been removed (crbug.com/937746).
              * This property used to return the imported document for the HTMLImport links.
              * The property is always undefined now.
+             * @deprecated
              */
             importedDocument?: Node;
             /**
@@ -6562,6 +6716,9 @@ export namespace Protocol {
             isSVG?: boolean;
             compatibilityMode?: CompatibilityMode;
             assignedSlot?: BackendNode;
+            /**
+             * @experimental
+             */
             isScrollable?: boolean;
         }
 
@@ -6788,7 +6945,8 @@ export namespace Protocol {
 
         export interface EnableRequest {
             /**
-             * Whether to include whitespaces in the children array of returned Nodes. (EnableRequestIncludeWhitespace enum)
+             * Whether to include whitespaces in the children array of returned Nodes.
+             * @experimental
              */
             includeWhitespace?: ('none' | 'all');
         }
@@ -6978,6 +7136,7 @@ export namespace Protocol {
             objectId?: Runtime.RemoteObjectId;
             /**
              * Include all shadow roots. Equals to false if not specified.
+             * @experimental
              */
             includeShadowDOM?: boolean;
         }
@@ -7154,7 +7313,7 @@ export namespace Protocol {
              */
             nodeId: NodeId;
             /**
-             * Type of relation to get. (GetElementByRelationRequestRelation enum)
+             * Type of relation to get.
              */
             relation: ('PopoverTarget' | 'InterestTarget' | 'CommandFor');
         }
@@ -7556,6 +7715,7 @@ export namespace Protocol {
 
         /**
          * Called when distribution is changed.
+         * @experimental
          */
         export interface DistributedNodesUpdatedEvent {
             /**
@@ -7570,6 +7730,7 @@ export namespace Protocol {
 
         /**
          * Fired when `Element`'s inline style is modified via a CSS property modification.
+         * @experimental
          */
         export interface InlineStyleInvalidatedEvent {
             /**
@@ -7580,6 +7741,7 @@ export namespace Protocol {
 
         /**
          * Called when a pseudo element is added to an element.
+         * @experimental
          */
         export interface PseudoElementAddedEvent {
             /**
@@ -7594,6 +7756,7 @@ export namespace Protocol {
 
         /**
          * Fired when a node's scrollability state changes.
+         * @experimental
          */
         export interface ScrollableFlagUpdatedEvent {
             /**
@@ -7608,6 +7771,7 @@ export namespace Protocol {
 
         /**
          * Called when a pseudo element is removed from an element.
+         * @experimental
          */
         export interface PseudoElementRemovedEvent {
             /**
@@ -7637,6 +7801,7 @@ export namespace Protocol {
 
         /**
          * Called when shadow root is popped from the element.
+         * @experimental
          */
         export interface ShadowRootPoppedEvent {
             /**
@@ -7651,6 +7816,7 @@ export namespace Protocol {
 
         /**
          * Called when shadow root is pushed into the element.
+         * @experimental
          */
         export interface ShadowRootPushedEvent {
             /**
@@ -7677,6 +7843,7 @@ export namespace Protocol {
 
         /**
          * CSP Violation type.
+         * @experimental
          */
         export type CSPViolationType = ('trustedtype-sink-violation' | 'trustedtype-policy-violation');
 
@@ -7768,6 +7935,7 @@ export namespace Protocol {
             eventName: string;
             /**
              * EventTarget interface name.
+             * @experimental
              */
             targetName?: string;
         }
@@ -7812,6 +7980,7 @@ export namespace Protocol {
             /**
              * EventTarget interface name to stop on. If equal to `"*"` or not provided, will stop on any
              * EventTarget.
+             * @experimental
              */
             targetName?: string;
         }
@@ -7835,6 +8004,7 @@ export namespace Protocol {
      * EventBreakpoints permits setting JavaScript breakpoints on operations and events
      * occurring in native code invoked from JavaScript. Once breakpoint is hit, it is
      * reported through Debugger domain, similarly to regular breakpoints being hit.
+     * @experimental
      */
     export namespace EventBreakpoints {
 
@@ -7855,6 +8025,7 @@ export namespace Protocol {
 
     /**
      * This domain facilitates obtaining document snapshots with DOM, layout, and style information.
+     * @experimental
      */
     export namespace DOMSnapshot {
 
@@ -8276,10 +8447,12 @@ export namespace Protocol {
             clientRects?: Rectangle[];
             /**
              * The list of background colors that are blended with colors of overlapping elements.
+             * @experimental
              */
             blendedBackgroundColors?: StringIndex[];
             /**
              * The list of computed text opacities.
+             * @experimental
              */
             textColorOpacities?: number[];
         }
@@ -8360,12 +8533,14 @@ export namespace Protocol {
              * Whether to include blended background colors in the snapshot (default: false).
              * Blended background color is achieved by blending background colors of all elements
              * that overlap with the current element.
+             * @experimental
              */
             includeBlendedBackgroundColors?: boolean;
             /**
              * Whether to include text color opacity in the snapshot (default: false).
              * An element might have the opacity property set that affects the text color of the element.
              * The final text color opacity is computed based on the opacity of all overlapping elements.
+             * @experimental
              */
             includeTextColorOpacities?: boolean;
         }
@@ -8384,6 +8559,7 @@ export namespace Protocol {
 
     /**
      * Query and modify DOM storage.
+     * @experimental
      */
     export namespace DOMStorage {
 
@@ -8458,6 +8634,9 @@ export namespace Protocol {
         }
     }
 
+    /**
+     * @experimental
+     */
     export namespace DeviceOrientation {
 
         export interface SetDeviceOrientationOverrideRequest {
@@ -8481,6 +8660,9 @@ export namespace Protocol {
      */
     export namespace Emulation {
 
+        /**
+         * @experimental
+         */
         export interface SafeAreaInsets {
             /**
              * Overrides safe-area-inset-top.
@@ -8528,7 +8710,7 @@ export namespace Protocol {
          */
         export interface ScreenOrientation {
             /**
-             * Orientation type. (ScreenOrientationType enum)
+             * Orientation type.
              */
             type: ('portraitPrimary' | 'portraitSecondary' | 'landscapePrimary' | 'landscapeSecondary');
             /**
@@ -8544,7 +8726,7 @@ export namespace Protocol {
 
         export interface DisplayFeature {
             /**
-             * Orientation of a display feature in relation to screen (DisplayFeatureOrientation enum)
+             * Orientation of a display feature in relation to screen
              */
             orientation: ('vertical' | 'horizontal');
             /**
@@ -8567,7 +8749,7 @@ export namespace Protocol {
 
         export interface DevicePosture {
             /**
-             * Current posture of the device (DevicePostureType enum)
+             * Current posture of the device
              */
             type: ('continuous' | 'folded');
         }
@@ -8582,11 +8764,13 @@ export namespace Protocol {
          * allow the next delayed task (if any) to run; pause: The virtual time base may not advance;
          * pauseIfNetworkFetchesPending: The virtual time base may not advance if there are any pending
          * resource fetches.
+         * @experimental
          */
         export type VirtualTimePolicy = ('advance' | 'pause' | 'pauseIfNetworkFetchesPending');
 
         /**
          * Used to specify User Agent Client Hints to emulate. See https://wicg.github.io/ua-client-hints
+         * @experimental
          */
         export interface UserAgentBrandVersion {
             brand: string;
@@ -8596,6 +8780,7 @@ export namespace Protocol {
         /**
          * Used to specify User Agent Client Hints to emulate. See https://wicg.github.io/ua-client-hints
          * Missing optional values will be filled in by the target with what it would normally use.
+         * @experimental
          */
         export interface UserAgentMetadata {
             /**
@@ -8606,6 +8791,9 @@ export namespace Protocol {
              * Brands appearing in Sec-CH-UA-Full-Version-List.
              */
             fullVersionList?: UserAgentBrandVersion[];
+            /**
+             * @deprecated
+             */
             fullVersion?: string;
             platform: string;
             platformVersion: string;
@@ -8624,25 +8812,38 @@ export namespace Protocol {
         /**
          * Used to specify sensor types to emulate.
          * See https://w3c.github.io/sensors/#automation for more information.
+         * @experimental
          */
         export type SensorType = ('absolute-orientation' | 'accelerometer' | 'ambient-light' | 'gravity' | 'gyroscope' | 'linear-acceleration' | 'magnetometer' | 'relative-orientation');
 
+        /**
+         * @experimental
+         */
         export interface SensorMetadata {
             available?: boolean;
             minimumFrequency?: number;
             maximumFrequency?: number;
         }
 
+        /**
+         * @experimental
+         */
         export interface SensorReadingSingle {
             value: number;
         }
 
+        /**
+         * @experimental
+         */
         export interface SensorReadingXYZ {
             x: number;
             y: number;
             z: number;
         }
 
+        /**
+         * @experimental
+         */
         export interface SensorReadingQuaternion {
             x: number;
             y: number;
@@ -8650,22 +8851,35 @@ export namespace Protocol {
             w: number;
         }
 
+        /**
+         * @experimental
+         */
         export interface SensorReading {
             single?: SensorReadingSingle;
             xyz?: SensorReadingXYZ;
             quaternion?: SensorReadingQuaternion;
         }
 
+        /**
+         * @experimental
+         */
         export type PressureSource = ('cpu');
 
+        /**
+         * @experimental
+         */
         export type PressureState = ('nominal' | 'fair' | 'serious' | 'critical');
 
+        /**
+         * @experimental
+         */
         export interface PressureMetadata {
             available?: boolean;
         }
 
         /**
          * Enum of image types that can be disabled.
+         * @experimental
          */
         export type DisabledImageType = ('avif' | 'webp');
 
@@ -8730,26 +8944,32 @@ export namespace Protocol {
             mobile: boolean;
             /**
              * Scale to apply to resulting view image.
+             * @experimental
              */
             scale?: number;
             /**
              * Overriding screen width value in pixels (minimum 0, maximum 10000000).
+             * @experimental
              */
             screenWidth?: integer;
             /**
              * Overriding screen height value in pixels (minimum 0, maximum 10000000).
+             * @experimental
              */
             screenHeight?: integer;
             /**
              * Overriding view X position on screen in pixels (minimum 0, maximum 10000000).
+             * @experimental
              */
             positionX?: integer;
             /**
              * Overriding view Y position on screen in pixels (minimum 0, maximum 10000000).
+             * @experimental
              */
             positionY?: integer;
             /**
              * Do not set visible view size, rely upon explicit setVisibleSize call.
+             * @experimental
              */
             dontSetVisibleSize?: boolean;
             /**
@@ -8759,18 +8979,23 @@ export namespace Protocol {
             /**
              * If set, the visible area of the page will be overridden to this viewport. This viewport
              * change is not observed by the page, e.g. viewport-relative elements do not change positions.
+             * @experimental
              */
             viewport?: Page.Viewport;
             /**
              * If set, the display feature of a multi-segment screen. If not set, multi-segment support
              * is turned-off.
              * Deprecated, use Emulation.setDisplayFeaturesOverride.
+             * @deprecated
+             * @experimental
              */
             displayFeature?: DisplayFeature;
             /**
              * If set, the posture of a foldable device. If not set the posture is set
              * to continuous.
              * Deprecated, use Emulation.setDevicePostureOverride.
+             * @deprecated
+             * @experimental
              */
             devicePosture?: DevicePosture;
         }
@@ -8808,7 +9033,7 @@ export namespace Protocol {
              */
             enabled: boolean;
             /**
-             * Touch/gesture events configuration. Default: current platform. (SetEmitTouchEventsForMouseRequestConfiguration enum)
+             * Touch/gesture events configuration. Default: current platform.
              */
             configuration?: ('mobile' | 'desktop');
         }
@@ -8837,7 +9062,7 @@ export namespace Protocol {
         export interface SetEmulatedVisionDeficiencyRequest {
             /**
              * Vision deficiency to emulate. Order: best-effort emulations come first, followed by any
-             * physiologically accurate emulations for medically recognized color vision deficiencies. (SetEmulatedVisionDeficiencyRequestType enum)
+             * physiologically accurate emulations for medically recognized color vision deficiencies.
              */
             type: ('none' | 'blurredVision' | 'reducedContrast' | 'achromatopsia' | 'deuteranopia' | 'protanopia' | 'tritanopia');
         }
@@ -9045,6 +9270,7 @@ export namespace Protocol {
             platform?: string;
             /**
              * To be sent in Sec-CH-UA-* headers and returned in navigator.userAgentData
+             * @experimental
              */
             userAgentMetadata?: UserAgentMetadata;
         }
@@ -9067,6 +9293,7 @@ export namespace Protocol {
 
     /**
      * This domain provides experimental commands only supported in headless mode.
+     * @experimental
      */
     export namespace HeadlessExperimental {
 
@@ -9081,7 +9308,7 @@ export namespace Protocol {
          */
         export interface ScreenshotParams {
             /**
-             * Image compression format (defaults to png). (ScreenshotParamsFormat enum)
+             * Image compression format (defaults to png).
              */
             format?: ('jpeg' | 'png' | 'webp');
             /**
@@ -9196,6 +9423,9 @@ export namespace Protocol {
         }
     }
 
+    /**
+     * @experimental
+     */
     export namespace FileSystem {
 
         export interface File {
@@ -9247,6 +9477,9 @@ export namespace Protocol {
         }
     }
 
+    /**
+     * @experimental
+     */
     export namespace IndexedDB {
 
         /**
@@ -9324,7 +9557,7 @@ export namespace Protocol {
          */
         export interface Key {
             /**
-             * Key type. (KeyType enum)
+             * Key type.
              */
             type: ('number' | 'string' | 'date' | 'array');
             /**
@@ -9396,7 +9629,7 @@ export namespace Protocol {
          */
         export interface KeyPath {
             /**
-             * Key path type. (KeyPathType enum)
+             * Key path type.
              */
             type: ('null' | 'string' | 'array');
             /**
@@ -9644,6 +9877,7 @@ export namespace Protocol {
             force?: number;
             /**
              * The normalized tangential pressure, which has a range of [-1,1] (default: 0).
+             * @experimental
              */
             tangentialPressure?: number;
             /**
@@ -9656,6 +9890,7 @@ export namespace Protocol {
             tiltY?: number;
             /**
              * The clockwise rotation of a pen stylus around its own major axis, in degrees in the range [0,359] (default: 0).
+             * @experimental
              */
             twist?: integer;
             /**
@@ -9664,6 +9899,9 @@ export namespace Protocol {
             id?: number;
         }
 
+        /**
+         * @experimental
+         */
         export type GestureSourceType = ('default' | 'touch' | 'mouse');
 
         export type MouseButton = ('none' | 'left' | 'middle' | 'right' | 'back' | 'forward');
@@ -9673,6 +9911,9 @@ export namespace Protocol {
          */
         export type TimeSinceEpoch = number;
 
+        /**
+         * @experimental
+         */
         export interface DragDataItem {
             /**
              * Mime type of the dragged data.
@@ -9694,6 +9935,9 @@ export namespace Protocol {
             baseURL?: string;
         }
 
+        /**
+         * @experimental
+         */
         export interface DragData {
             items: DragDataItem[];
             /**
@@ -9715,7 +9959,7 @@ export namespace Protocol {
 
         export interface DispatchDragEventRequest {
             /**
-             * Type of the drag event. (DispatchDragEventRequestType enum)
+             * Type of the drag event.
              */
             type: ('dragEnter' | 'dragOver' | 'drop' | 'dragCancel');
             /**
@@ -9744,7 +9988,7 @@ export namespace Protocol {
 
         export interface DispatchKeyEventRequest {
             /**
-             * Type of the key event. (DispatchKeyEventRequestType enum)
+             * Type of the key event.
              */
             type: ('keyDown' | 'keyUp' | 'rawKeyDown' | 'char');
             /**
@@ -9808,6 +10052,7 @@ export namespace Protocol {
              * Editing commands to send with the key event (e.g., 'selectAll') (default: []).
              * These are related to but not equal the command names used in `document.execCommand` and NSStandardKeyBindingResponding.
              * See https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/editing/commands/editor_command_names.h for valid command names.
+             * @experimental
              */
             commands?: string[];
         }
@@ -9856,7 +10101,7 @@ export namespace Protocol {
 
         export interface DispatchMouseEventRequest {
             /**
-             * Type of the mouse event. (DispatchMouseEventRequestType enum)
+             * Type of the mouse event.
              */
             type: ('mousePressed' | 'mouseReleased' | 'mouseMoved' | 'mouseWheel');
             /**
@@ -9892,10 +10137,12 @@ export namespace Protocol {
             clickCount?: integer;
             /**
              * The normalized pressure, which has a range of [0,1] (default: 0).
+             * @experimental
              */
             force?: number;
             /**
              * The normalized tangential pressure, which has a range of [-1,1] (default: 0).
+             * @experimental
              */
             tangentialPressure?: number;
             /**
@@ -9908,6 +10155,7 @@ export namespace Protocol {
             tiltY?: number;
             /**
              * The clockwise rotation of a pen stylus around its own major axis, in degrees in the range [0,359] (default: 0).
+             * @experimental
              */
             twist?: integer;
             /**
@@ -9919,7 +10167,7 @@ export namespace Protocol {
              */
             deltaY?: number;
             /**
-             * Pointer type (default: "mouse"). (DispatchMouseEventRequestPointerType enum)
+             * Pointer type (default: "mouse").
              */
             pointerType?: ('mouse' | 'pen');
         }
@@ -9934,7 +10182,7 @@ export namespace Protocol {
         export interface DispatchTouchEventRequest {
             /**
              * Type of the touch event. TouchEnd and TouchCancel must not contain any touch points, while
-             * TouchStart and TouchMove must contains at least one. (DispatchTouchEventRequestType enum)
+             * TouchStart and TouchMove must contains at least one.
              */
             type: ('touchStart' | 'touchEnd' | 'touchMove' | 'touchCancel');
             /**
@@ -9963,7 +10211,7 @@ export namespace Protocol {
 
         export interface EmulateTouchFromMouseEventRequest {
             /**
-             * Type of the mouse event. (EmulateTouchFromMouseEventRequestType enum)
+             * Type of the mouse event.
              */
             type: ('mousePressed' | 'mouseReleased' | 'mouseMoved' | 'mouseWheel');
             /**
@@ -10117,12 +10365,16 @@ export namespace Protocol {
         /**
          * Emitted only when `Input.setInterceptDrags` is enabled. Use this data with `Input.dispatchDragEvent` to
          * restore normal drag and drop behavior.
+         * @experimental
          */
         export interface DragInterceptedEvent {
             data: DragData;
         }
     }
 
+    /**
+     * @experimental
+     */
     export namespace Inspector {
 
         /**
@@ -10136,6 +10388,9 @@ export namespace Protocol {
         }
     }
 
+    /**
+     * @experimental
+     */
     export namespace LayerTree {
 
         /**
@@ -10163,7 +10418,7 @@ export namespace Protocol {
              */
             rect: DOM.Rect;
             /**
-             * Reason for rectangle to force scrolling on the main thread (ScrollRectType enum)
+             * Reason for rectangle to force scrolling on the main thread
              */
             type: ('RepaintsOnScroll' | 'TouchEventHandler' | 'WheelEventHandler');
         }
@@ -10459,20 +10714,17 @@ export namespace Protocol {
          */
         export interface LogEntry {
             /**
-             * Log entry source. (LogEntrySource enum)
+             * Log entry source.
              */
             source: ('xml' | 'javascript' | 'network' | 'storage' | 'appcache' | 'rendering' | 'security' | 'deprecation' | 'worker' | 'violation' | 'intervention' | 'recommendation' | 'other');
             /**
-             * Log entry severity. (LogEntryLevel enum)
+             * Log entry severity.
              */
             level: ('verbose' | 'info' | 'warning' | 'error');
             /**
              * Logged text.
              */
             text: string;
-            /**
-             *  (LogEntryCategory enum)
-             */
             category?: ('cors');
             /**
              * Timestamp when this entry was added.
@@ -10519,7 +10771,7 @@ export namespace Protocol {
          */
         export interface ViolationSetting {
             /**
-             * Violation type. (ViolationSettingName enum)
+             * Violation type.
              */
             name: ('longTask' | 'longLayout' | 'blockedEvent' | 'blockedParser' | 'discouragedAPIUse' | 'handler' | 'recurringHandler');
             /**
@@ -10546,6 +10798,9 @@ export namespace Protocol {
         }
     }
 
+    /**
+     * @experimental
+     */
     export namespace Memory {
 
         /**
@@ -10732,6 +10987,7 @@ export namespace Protocol {
         /**
          * Represents the cookie's 'Priority' status:
          * https://tools.ietf.org/html/draft-west-cookie-priority-00
+         * @experimental
          */
         export type CookiePriority = ('Low' | 'Medium' | 'High');
 
@@ -10739,6 +10995,7 @@ export namespace Protocol {
          * Represents the source scheme of the origin that originally set the cookie.
          * A value of "Unset" allows protocol clients to emulate legacy cookie scope for the scheme.
          * This is a temporary ability and it will be removed in the future.
+         * @experimental
          */
         export type CookieSourceScheme = ('Unset' | 'NonSecure' | 'Secure');
 
@@ -10785,26 +11042,32 @@ export namespace Protocol {
             sslEnd: number;
             /**
              * Started running ServiceWorker.
+             * @experimental
              */
             workerStart: number;
             /**
              * Finished Starting ServiceWorker.
+             * @experimental
              */
             workerReady: number;
             /**
              * Started fetch event.
+             * @experimental
              */
             workerFetchStart: number;
             /**
              * Settled fetch event respondWith promise.
+             * @experimental
              */
             workerRespondWithSettled: number;
             /**
              * Started ServiceWorker static routing source evaluation.
+             * @experimental
              */
             workerRouterEvaluationStart?: number;
             /**
              * Started cache lookup when the source was evaluated to `cache`.
+             * @experimental
              */
             workerCacheLookupStart?: number;
             /**
@@ -10817,14 +11080,17 @@ export namespace Protocol {
             sendEnd: number;
             /**
              * Time the server started pushing request.
+             * @experimental
              */
             pushStart: number;
             /**
              * Time the server finished pushing request.
+             * @experimental
              */
             pushEnd: number;
             /**
              * Started receiving response headers.
+             * @experimental
              */
             receiveHeadersStart: number;
             /**
@@ -10879,6 +11145,7 @@ export namespace Protocol {
             /**
              * HTTP POST request data.
              * Use postDataEntries instead.
+             * @deprecated
              */
             postData?: string;
             /**
@@ -10887,6 +11154,7 @@ export namespace Protocol {
             hasPostData?: boolean;
             /**
              * Request body elements (post data broken into individual entries).
+             * @experimental
              */
             postDataEntries?: PostDataEntry[];
             /**
@@ -10898,7 +11166,7 @@ export namespace Protocol {
              */
             initialPriority: ResourcePriority;
             /**
-             * The referrer policy of the request, as defined in https://www.w3.org/TR/referrer-policy/ (RequestReferrerPolicy enum)
+             * The referrer policy of the request, as defined in https://www.w3.org/TR/referrer-policy/
              */
             referrerPolicy: ('unsafe-url' | 'no-referrer-when-downgrade' | 'no-referrer' | 'origin' | 'origin-when-cross-origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin');
             /**
@@ -10908,11 +11176,13 @@ export namespace Protocol {
             /**
              * Set for requests when the TrustToken API is used. Contains the parameters
              * passed by the developer (e.g. via "fetch") as understood by the backend.
+             * @experimental
              */
             trustTokenParams?: TrustTokenParams;
             /**
              * True if this resource request is considered to be the 'same site' as the
              * request corresponding to the main frame.
+             * @experimental
              */
             isSameSite?: boolean;
         }
@@ -11058,12 +11328,13 @@ export namespace Protocol {
          * Determines what type of Trust Token operation is executed and
          * depending on the type, some additional parameters. The values
          * are specified in third_party/blink/renderer/core/fetch/trust_token.idl.
+         * @experimental
          */
         export interface TrustTokenParams {
             operation: TrustTokenOperationType;
             /**
              * Only set for "token-redemption" operation and determine whether
-             * to request a fresh SRR or use a still valid cached SRR. (TrustTokenParamsRefreshPolicy enum)
+             * to request a fresh SRR or use a still valid cached SRR.
              */
             refreshPolicy: ('UseCached' | 'Refresh');
             /**
@@ -11073,10 +11344,14 @@ export namespace Protocol {
             issuers?: string[];
         }
 
+        /**
+         * @experimental
+         */
         export type TrustTokenOperationType = ('Issuance' | 'Redemption' | 'Signing');
 
         /**
          * The reason why Chrome uses a specific transport protocol for HTTP semantics.
+         * @experimental
          */
         export type AlternateProtocolUsage = ('alternativeJobWonWithoutRace' | 'alternativeJobWonRace' | 'mainJobWonRace' | 'mappingMissing' | 'broken' | 'dnsAlpnH3JobWonWithoutRace' | 'dnsAlpnH3JobWonRace' | 'unspecifiedReason');
 
@@ -11085,6 +11360,9 @@ export namespace Protocol {
          */
         export type ServiceWorkerRouterSource = ('network' | 'cache' | 'fetch-event' | 'race-network-and-fetch-handler' | 'race-network-and-cache');
 
+        /**
+         * @experimental
+         */
         export interface ServiceWorkerRouterInfo {
             /**
              * ID of the rule matched. If there is a matched rule, this field will
@@ -11124,6 +11402,7 @@ export namespace Protocol {
             headers: Headers;
             /**
              * HTTP response headers text. This has been replaced by the headers in Network.responseReceivedExtraInfo.
+             * @deprecated
              */
             headersText?: string;
             /**
@@ -11140,6 +11419,7 @@ export namespace Protocol {
             requestHeaders?: Headers;
             /**
              * HTTP request headers text. This has been replaced by the headers in Network.requestWillBeSentExtraInfo.
+             * @deprecated
              */
             requestHeadersText?: string;
             /**
@@ -11179,6 +11459,7 @@ export namespace Protocol {
              * field is set with `matchedSourceType` field, a matching rule is found.
              * If this field is set without `matchedSource`, no matching rule is found.
              * Otherwise, the API is not used.
+             * @experimental
              */
             serviceWorkerRouterInfo?: ServiceWorkerRouterInfo;
             /**
@@ -11207,6 +11488,7 @@ export namespace Protocol {
             protocol?: string;
             /**
              * The reason why Chrome uses a specific transport protocol for HTTP semantics.
+             * @experimental
              */
             alternateProtocolUsage?: AlternateProtocolUsage;
             /**
@@ -11220,6 +11502,7 @@ export namespace Protocol {
             /**
              * Indicates whether the request was sent through IP Protection proxies. If
              * set to true, the request used the IP Protection privacy feature.
+             * @experimental
              */
             isIpProtectionUsed?: boolean;
         }
@@ -11320,7 +11603,7 @@ export namespace Protocol {
          */
         export interface Initiator {
             /**
-             * Type of this initiator. (InitiatorType enum)
+             * Type of this initiator.
              */
             type: ('parser' | 'script' | 'preload' | 'SignedExchange' | 'preflight' | 'other');
             /**
@@ -11351,6 +11634,7 @@ export namespace Protocol {
         /**
          * cookiePartitionKey object
          * The representation of the components of the key that are created by the cookiePartitionKey class contained in net/cookies/cookie_partition_key.h.
+         * @experimental
          */
         export interface CookiePartitionKey {
             /**
@@ -11410,49 +11694,60 @@ export namespace Protocol {
             sameSite?: CookieSameSite;
             /**
              * Cookie Priority
+             * @experimental
              */
             priority: CookiePriority;
             /**
              * True if cookie is SameParty.
+             * @deprecated
+             * @experimental
              */
             sameParty: boolean;
             /**
              * Cookie source scheme type.
+             * @experimental
              */
             sourceScheme: CookieSourceScheme;
             /**
              * Cookie source port. Valid values are {-1, [1, 65535]}, -1 indicates an unspecified port.
              * An unspecified port value allows protocol clients to emulate legacy cookie scope for the port.
              * This is a temporary ability and it will be removed in the future.
+             * @experimental
              */
             sourcePort: integer;
             /**
              * Cookie partition key.
+             * @experimental
              */
             partitionKey?: CookiePartitionKey;
             /**
              * True if cookie partition key is opaque.
+             * @experimental
              */
             partitionKeyOpaque?: boolean;
         }
 
         /**
          * Types of reasons why a cookie may not be stored from a response.
+         * @experimental
          */
         export type SetCookieBlockedReason = ('SecureOnly' | 'SameSiteStrict' | 'SameSiteLax' | 'SameSiteUnspecifiedTreatedAsLax' | 'SameSiteNoneInsecure' | 'UserPreferences' | 'ThirdPartyPhaseout' | 'ThirdPartyBlockedInFirstPartySet' | 'SyntaxError' | 'SchemeNotSupported' | 'OverwriteSecure' | 'InvalidDomain' | 'InvalidPrefix' | 'UnknownError' | 'SchemefulSameSiteStrict' | 'SchemefulSameSiteLax' | 'SchemefulSameSiteUnspecifiedTreatedAsLax' | 'SamePartyFromCrossPartyContext' | 'SamePartyConflictsWithOtherAttributes' | 'NameValuePairExceedsMaxSize' | 'DisallowedCharacter' | 'NoCookieContent');
 
         /**
          * Types of reasons why a cookie may not be sent with a request.
+         * @experimental
          */
         export type CookieBlockedReason = ('SecureOnly' | 'NotOnPath' | 'DomainMismatch' | 'SameSiteStrict' | 'SameSiteLax' | 'SameSiteUnspecifiedTreatedAsLax' | 'SameSiteNoneInsecure' | 'UserPreferences' | 'ThirdPartyPhaseout' | 'ThirdPartyBlockedInFirstPartySet' | 'UnknownError' | 'SchemefulSameSiteStrict' | 'SchemefulSameSiteLax' | 'SchemefulSameSiteUnspecifiedTreatedAsLax' | 'SamePartyFromCrossPartyContext' | 'NameValuePairExceedsMaxSize' | 'PortMismatch' | 'SchemeMismatch' | 'AnonymousContext');
 
         /**
          * Types of reasons why a cookie should have been blocked by 3PCD but is exempted for the request.
+         * @experimental
          */
         export type CookieExemptionReason = ('None' | 'UserSetting' | 'TPCDMetadata' | 'TPCDDeprecationTrial' | 'TopLevelTPCDDeprecationTrial' | 'TPCDHeuristics' | 'EnterprisePolicy' | 'StorageAccess' | 'TopLevelStorageAccess' | 'Scheme' | 'SameSiteNoneCookiesInSandbox');
 
         /**
          * A cookie which was not stored from a response with the corresponding reason.
+         * @experimental
          */
         export interface BlockedSetCookieWithReason {
             /**
@@ -11475,6 +11770,7 @@ export namespace Protocol {
         /**
          * A cookie should have been blocked by 3PCD but is exempted and stored from a response with the
          * corresponding reason. A cookie could only have at most one exemption reason.
+         * @experimental
          */
         export interface ExemptedSetCookieWithReason {
             /**
@@ -11494,6 +11790,7 @@ export namespace Protocol {
         /**
          * A cookie associated with the request which may or may not be sent with it.
          * Includes the cookies itself and reasons for blocking or exemption.
+         * @experimental
          */
         export interface AssociatedCookie {
             /**
@@ -11554,24 +11851,29 @@ export namespace Protocol {
             expires?: TimeSinceEpoch;
             /**
              * Cookie Priority.
+             * @experimental
              */
             priority?: CookiePriority;
             /**
              * True if cookie is SameParty.
+             * @experimental
              */
             sameParty?: boolean;
             /**
              * Cookie source scheme type.
+             * @experimental
              */
             sourceScheme?: CookieSourceScheme;
             /**
              * Cookie source port. Valid values are {-1, [1, 65535]}, -1 indicates an unspecified port.
              * An unspecified port value allows protocol clients to emulate legacy cookie scope for the port.
              * This is a temporary ability and it will be removed in the future.
+             * @experimental
              */
             sourcePort?: integer;
             /**
              * Cookie partition key. If not set, the cookie will be set as not partitioned.
+             * @experimental
              */
             partitionKey?: CookiePartitionKey;
         }
@@ -11583,10 +11885,11 @@ export namespace Protocol {
 
         /**
          * Authorization challenge for HTTP status code 401 or 407.
+         * @experimental
          */
         export interface AuthChallenge {
             /**
-             * Source of the authentication challenge. (AuthChallengeSource enum)
+             * Source of the authentication challenge.
              */
             source?: ('Server' | 'Proxy');
             /**
@@ -11611,12 +11914,13 @@ export namespace Protocol {
 
         /**
          * Response to an AuthChallenge.
+         * @experimental
          */
         export interface AuthChallengeResponse {
             /**
              * The decision on what to do in response to the authorization challenge.  Default means
              * deferring to the default behavior of the net stack, which will likely either the Cancel
-             * authentication or display a popup dialog box. (AuthChallengeResponseResponse enum)
+             * authentication or display a popup dialog box.
              */
             response: ('Default' | 'CancelAuth' | 'ProvideCredentials');
             /**
@@ -11634,11 +11938,13 @@ export namespace Protocol {
         /**
          * Stages of the interception to begin intercepting. Request will intercept before the request is
          * sent. Response will intercept after the response is received.
+         * @experimental
          */
         export type InterceptionStage = ('Request' | 'HeadersReceived');
 
         /**
          * Request pattern for interception.
+         * @experimental
          */
         export interface RequestPattern {
             /**
@@ -11659,6 +11965,7 @@ export namespace Protocol {
         /**
          * Information about a signed exchange signature.
          * https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#rfc.section.3.1
+         * @experimental
          */
         export interface SignedExchangeSignature {
             /**
@@ -11702,6 +12009,7 @@ export namespace Protocol {
         /**
          * Information about a signed exchange header.
          * https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#cbor-representation
+         * @experimental
          */
         export interface SignedExchangeHeader {
             /**
@@ -11728,11 +12036,13 @@ export namespace Protocol {
 
         /**
          * Field type for a signed exchange related error.
+         * @experimental
          */
         export type SignedExchangeErrorField = ('signatureSig' | 'signatureIntegrity' | 'signatureCertUrl' | 'signatureCertSha256' | 'signatureValidityUrl' | 'signatureTimestamps');
 
         /**
          * Information about a signed exchange response.
+         * @experimental
          */
         export interface SignedExchangeError {
             /**
@@ -11751,6 +12061,7 @@ export namespace Protocol {
 
         /**
          * Information about a signed exchange response.
+         * @experimental
          */
         export interface SignedExchangeInfo {
             /**
@@ -11778,11 +12089,18 @@ export namespace Protocol {
 
         /**
          * List of content encodings supported by the backend.
+         * @experimental
          */
         export type ContentEncoding = ('deflate' | 'gzip' | 'br' | 'zstd');
 
+        /**
+         * @experimental
+         */
         export type DirectSocketDnsQueryType = ('ipv4' | 'ipv6');
 
+        /**
+         * @experimental
+         */
         export interface DirectTCPSocketOptions {
             /**
              * TCP_NODELAY option
@@ -11803,6 +12121,9 @@ export namespace Protocol {
             dnsQueryType?: DirectSocketDnsQueryType;
         }
 
+        /**
+         * @experimental
+         */
         export interface DirectUDPSocketOptions {
             remoteAddr?: string;
             /**
@@ -11825,6 +12146,9 @@ export namespace Protocol {
             receiveBufferSize?: number;
         }
 
+        /**
+         * @experimental
+         */
         export interface DirectUDPMessage {
             data: string;
             /**
@@ -11838,10 +12162,19 @@ export namespace Protocol {
             remotePort?: integer;
         }
 
+        /**
+         * @experimental
+         */
         export type PrivateNetworkRequestPolicy = ('Allow' | 'BlockFromInsecureToMorePrivate' | 'WarnFromInsecureToMorePrivate' | 'PreflightBlock' | 'PreflightWarn' | 'PermissionBlock' | 'PermissionWarn');
 
+        /**
+         * @experimental
+         */
         export type IPAddressSpace = ('Loopback' | 'Local' | 'Public' | 'Unknown');
 
+        /**
+         * @experimental
+         */
         export interface ConnectTiming {
             /**
              * Timing's requestTime is a baseline in seconds, while the other numbers are ticks in
@@ -11851,14 +12184,23 @@ export namespace Protocol {
             requestTime: number;
         }
 
+        /**
+         * @experimental
+         */
         export interface ClientSecurityState {
             initiatorIsSecureContext: boolean;
             initiatorIPAddressSpace: IPAddressSpace;
             privateNetworkRequestPolicy: PrivateNetworkRequestPolicy;
         }
 
+        /**
+         * @experimental
+         */
         export type CrossOriginOpenerPolicyValue = ('SameOrigin' | 'SameOriginAllowPopups' | 'RestrictProperties' | 'UnsafeNone' | 'SameOriginPlusCoep' | 'RestrictPropertiesPlusCoep' | 'NoopenerAllowPopups');
 
+        /**
+         * @experimental
+         */
         export interface CrossOriginOpenerPolicyStatus {
             value: CrossOriginOpenerPolicyValue;
             reportOnlyValue: CrossOriginOpenerPolicyValue;
@@ -11866,8 +12208,14 @@ export namespace Protocol {
             reportOnlyReportingEndpoint?: string;
         }
 
+        /**
+         * @experimental
+         */
         export type CrossOriginEmbedderPolicyValue = ('None' | 'Credentialless' | 'RequireCorp');
 
+        /**
+         * @experimental
+         */
         export interface CrossOriginEmbedderPolicyStatus {
             value: CrossOriginEmbedderPolicyValue;
             reportOnlyValue: CrossOriginEmbedderPolicyValue;
@@ -11875,14 +12223,23 @@ export namespace Protocol {
             reportOnlyReportingEndpoint?: string;
         }
 
+        /**
+         * @experimental
+         */
         export type ContentSecurityPolicySource = ('HTTP' | 'Meta');
 
+        /**
+         * @experimental
+         */
         export interface ContentSecurityPolicyStatus {
             effectiveDirectives: string;
             isEnforced: boolean;
             source: ContentSecurityPolicySource;
         }
 
+        /**
+         * @experimental
+         */
         export interface SecurityIsolationStatus {
             coop?: CrossOriginOpenerPolicyStatus;
             coep?: CrossOriginEmbedderPolicyStatus;
@@ -11891,13 +12248,18 @@ export namespace Protocol {
 
         /**
          * The status of a Reporting API report.
+         * @experimental
          */
         export type ReportStatus = ('Queued' | 'Pending' | 'MarkedForRemoval' | 'Success');
 
+        /**
+         * @experimental
+         */
         export type ReportId = string;
 
         /**
          * An object representing a report generated by the Reporting API.
+         * @experimental
          */
         export interface ReportingApiReport {
             id: ReportId;
@@ -11929,6 +12291,9 @@ export namespace Protocol {
             status: ReportStatus;
         }
 
+        /**
+         * @experimental
+         */
         export interface ReportingApiEndpoint {
             /**
              * The URL of the endpoint to which reports may be delivered.
@@ -11942,6 +12307,7 @@ export namespace Protocol {
 
         /**
          * An object providing the result of a network resource load.
+         * @experimental
          */
         export interface LoadNetworkResourcePageResult {
             success: boolean;
@@ -11964,6 +12330,7 @@ export namespace Protocol {
         /**
          * An options object that may be extended later to better support CORS,
          * CORB and streaming.
+         * @experimental
          */
         export interface LoadNetworkResourceOptions {
             disableCache: boolean;
@@ -12057,6 +12424,7 @@ export namespace Protocol {
             /**
              * If specified, deletes only cookies with the the given name and partitionKey where
              * all partition key attributes match the cookie partition key attribute.
+             * @experimental
              */
             partitionKey?: CookiePartitionKey;
         }
@@ -12084,14 +12452,17 @@ export namespace Protocol {
             connectionType?: ConnectionType;
             /**
              * WebRTC packet loss (percent, 0-100). 0 disables packet loss emulation, 100 drops all the packets.
+             * @experimental
              */
             packetLoss?: number;
             /**
              * WebRTC packet queue length (packet). 0 removes any queue length limitations.
+             * @experimental
              */
             packetQueueLength?: integer;
             /**
              * WebRTC packetReordering feature.
+             * @experimental
              */
             packetReordering?: boolean;
         }
@@ -12099,10 +12470,12 @@ export namespace Protocol {
         export interface EnableRequest {
             /**
              * Buffer size in bytes to use when preserving network payloads (XHRs, etc).
+             * @experimental
              */
             maxTotalBufferSize?: integer;
             /**
              * Per-resource buffer size in bytes to use when preserving network payloads (XHRs, etc).
+             * @experimental
              */
             maxResourceBufferSize?: integer;
             /**
@@ -12111,6 +12484,7 @@ export namespace Protocol {
             maxPostDataSize?: integer;
             /**
              * Whether DirectSocket chunk send/receive events should be reported.
+             * @experimental
              */
             reportDirectSocketTraffic?: boolean;
         }
@@ -12301,24 +12675,29 @@ export namespace Protocol {
             expires?: TimeSinceEpoch;
             /**
              * Cookie Priority type.
+             * @experimental
              */
             priority?: CookiePriority;
             /**
              * True if cookie is SameParty.
+             * @experimental
              */
             sameParty?: boolean;
             /**
              * Cookie source scheme type.
+             * @experimental
              */
             sourceScheme?: CookieSourceScheme;
             /**
              * Cookie source port. Valid values are {-1, [1, 65535]}, -1 indicates an unspecified port.
              * An unspecified port value allows protocol clients to emulate legacy cookie scope for the port.
              * This is a temporary ability and it will be removed in the future.
+             * @experimental
              */
             sourcePort?: integer;
             /**
              * Cookie partition key. If not set, the cookie will be set as not partitioned.
+             * @experimental
              */
             partitionKey?: CookiePartitionKey;
         }
@@ -12326,6 +12705,7 @@ export namespace Protocol {
         export interface SetCookieResponse {
             /**
              * Always set to true. If an error occurs, the response indicates protocol error.
+             * @deprecated
              */
             success: boolean;
         }
@@ -12374,6 +12754,7 @@ export namespace Protocol {
             platform?: string;
             /**
              * To be sent in Sec-CH-UA-* headers and returned in navigator.userAgentData
+             * @experimental
              */
             userAgentMetadata?: Emulation.UserAgentMetadata;
         }
@@ -12467,6 +12848,7 @@ export namespace Protocol {
             encodedDataLength: integer;
             /**
              * Data that was received. (Encoded as a base64 string when passed over JSON)
+             * @experimental
              */
             data?: string;
         }
@@ -12553,6 +12935,8 @@ export namespace Protocol {
          * Details of an intercepted HTTP request, which must be either allowed, blocked, modified or
          * mocked.
          * Deprecated, use Fetch.requestPaused instead.
+         * @deprecated
+         * @experimental
          */
         export interface RequestInterceptedEvent {
             /**
@@ -12656,6 +13040,7 @@ export namespace Protocol {
              * In the case that redirectResponse is populated, this flag indicates whether
              * requestWillBeSentExtraInfo and responseReceivedExtraInfo events will be or were emitted
              * for the request which was just redirected.
+             * @experimental
              */
             redirectHasExtraInfo: boolean;
             /**
@@ -12678,6 +13063,7 @@ export namespace Protocol {
 
         /**
          * Fired when resource loading priority is changed
+         * @experimental
          */
         export interface ResourceChangedPriorityEvent {
             /**
@@ -12696,6 +13082,7 @@ export namespace Protocol {
 
         /**
          * Fired when a signed exchange was received over the network
+         * @experimental
          */
         export interface SignedExchangeReceivedEvent {
             /**
@@ -12735,6 +13122,7 @@ export namespace Protocol {
             /**
              * Indicates whether requestWillBeSentExtraInfo and responseReceivedExtraInfo events will be
              * or were emitted for this request.
+             * @experimental
              */
             hasExtraInfo: boolean;
             /**
@@ -12921,6 +13309,7 @@ export namespace Protocol {
 
         /**
          * Fired upon direct_socket.TCPSocket creation.
+         * @experimental
          */
         export interface DirectTCPSocketCreatedEvent {
             identifier: RequestId;
@@ -12936,6 +13325,7 @@ export namespace Protocol {
 
         /**
          * Fired when direct_socket.TCPSocket connection is opened.
+         * @experimental
          */
         export interface DirectTCPSocketOpenedEvent {
             identifier: RequestId;
@@ -12954,6 +13344,7 @@ export namespace Protocol {
 
         /**
          * Fired when direct_socket.TCPSocket is aborted.
+         * @experimental
          */
         export interface DirectTCPSocketAbortedEvent {
             identifier: RequestId;
@@ -12963,6 +13354,7 @@ export namespace Protocol {
 
         /**
          * Fired when direct_socket.TCPSocket is closed.
+         * @experimental
          */
         export interface DirectTCPSocketClosedEvent {
             identifier: RequestId;
@@ -12971,6 +13363,7 @@ export namespace Protocol {
 
         /**
          * Fired when data is sent to tcp direct socket stream.
+         * @experimental
          */
         export interface DirectTCPSocketChunkSentEvent {
             identifier: RequestId;
@@ -12980,6 +13373,7 @@ export namespace Protocol {
 
         /**
          * Fired when data is received from tcp direct socket stream.
+         * @experimental
          */
         export interface DirectTCPSocketChunkReceivedEvent {
             identifier: RequestId;
@@ -12989,6 +13383,7 @@ export namespace Protocol {
 
         /**
          * Fired upon direct_socket.UDPSocket creation.
+         * @experimental
          */
         export interface DirectUDPSocketCreatedEvent {
             identifier: RequestId;
@@ -12999,6 +13394,7 @@ export namespace Protocol {
 
         /**
          * Fired when direct_socket.UDPSocket connection is opened.
+         * @experimental
          */
         export interface DirectUDPSocketOpenedEvent {
             identifier: RequestId;
@@ -13017,6 +13413,7 @@ export namespace Protocol {
 
         /**
          * Fired when direct_socket.UDPSocket is aborted.
+         * @experimental
          */
         export interface DirectUDPSocketAbortedEvent {
             identifier: RequestId;
@@ -13026,6 +13423,7 @@ export namespace Protocol {
 
         /**
          * Fired when direct_socket.UDPSocket is closed.
+         * @experimental
          */
         export interface DirectUDPSocketClosedEvent {
             identifier: RequestId;
@@ -13034,6 +13432,7 @@ export namespace Protocol {
 
         /**
          * Fired when message is sent to udp direct socket stream.
+         * @experimental
          */
         export interface DirectUDPSocketChunkSentEvent {
             identifier: RequestId;
@@ -13043,6 +13442,7 @@ export namespace Protocol {
 
         /**
          * Fired when message is received from udp direct socket stream.
+         * @experimental
          */
         export interface DirectUDPSocketChunkReceivedEvent {
             identifier: RequestId;
@@ -13055,6 +13455,7 @@ export namespace Protocol {
          * network stack. Not every requestWillBeSent event will have an additional
          * requestWillBeSentExtraInfo fired for it, and there is no guarantee whether requestWillBeSent
          * or requestWillBeSentExtraInfo will be fired first for the same request.
+         * @experimental
          */
         export interface RequestWillBeSentExtraInfoEvent {
             /**
@@ -13072,6 +13473,7 @@ export namespace Protocol {
             headers: Headers;
             /**
              * Connection timing information for the request.
+             * @experimental
              */
             connectTiming: ConnectTiming;
             /**
@@ -13088,6 +13490,7 @@ export namespace Protocol {
          * Fired when additional information about a responseReceived event is available from the network
          * stack. Not every responseReceived event will have an additional responseReceivedExtraInfo for
          * it, and responseReceivedExtraInfo may be fired before or after responseReceived.
+         * @experimental
          */
         export interface ResponseReceivedExtraInfoEvent {
             /**
@@ -13126,6 +13529,7 @@ export namespace Protocol {
             /**
              * The cookie partition key that will be used to store partitioned cookies set in this response.
              * Only sent when partitioned cookies are enabled.
+             * @experimental
              */
             cookiePartitionKey?: CookiePartitionKey;
             /**
@@ -13143,6 +13547,7 @@ export namespace Protocol {
          * Fired when 103 Early Hints headers is received in addition to the common response.
          * Not every responseReceived event will have an responseReceivedEarlyHints fired.
          * Only one responseReceivedEarlyHints may be fired for eached responseReceived event.
+         * @experimental
          */
         export interface ResponseReceivedEarlyHintsEvent {
             /**
@@ -13179,13 +13584,14 @@ export namespace Protocol {
          * the type of the operation and whether the operation succeeded or
          * failed, the event is fired before the corresponding request was sent
          * or after the response was received.
+         * @experimental
          */
         export interface TrustTokenOperationDoneEvent {
             /**
              * Detailed success or error status of the operation.
              * 'AlreadyExists' also signifies a successful operation, as the result
              * of the operation already exists und thus, the operation was abort
-             * preemptively (e.g. a cache hit). (TrustTokenOperationDoneEventStatus enum)
+             * preemptively (e.g. a cache hit).
              */
             status: ('Ok' | 'InvalidArgument' | 'MissingIssuerKeys' | 'FailedPrecondition' | 'ResourceExhausted' | 'AlreadyExists' | 'ResourceLimited' | 'Unauthorized' | 'BadResponse' | 'InternalError' | 'UnknownError' | 'FulfilledLocally' | 'SiteIssuerLimit');
             type: TrustTokenOperationType;
@@ -13207,6 +13613,7 @@ export namespace Protocol {
         /**
          * Fired once when parsing the .wbn file has succeeded.
          * The event contains the information about the web bundle contents.
+         * @experimental
          */
         export interface SubresourceWebBundleMetadataReceivedEvent {
             /**
@@ -13221,6 +13628,7 @@ export namespace Protocol {
 
         /**
          * Fired once when parsing the .wbn file has failed.
+         * @experimental
          */
         export interface SubresourceWebBundleMetadataErrorEvent {
             /**
@@ -13236,6 +13644,7 @@ export namespace Protocol {
         /**
          * Fired when handling requests for resources within a .wbn file.
          * Note: this will only be fired for resources that are requested by the webpage.
+         * @experimental
          */
         export interface SubresourceWebBundleInnerResponseParsedEvent {
             /**
@@ -13256,6 +13665,7 @@ export namespace Protocol {
 
         /**
          * Fired when request for resources within a .wbn file failed.
+         * @experimental
          */
         export interface SubresourceWebBundleInnerResponseErrorEvent {
             /**
@@ -13281,15 +13691,22 @@ export namespace Protocol {
         /**
          * Is sent whenever a new report is added.
          * And after 'enableReportingApi' for all existing reports.
+         * @experimental
          */
         export interface ReportingApiReportAddedEvent {
             report: ReportingApiReport;
         }
 
+        /**
+         * @experimental
+         */
         export interface ReportingApiReportUpdatedEvent {
             report: ReportingApiReport;
         }
 
+        /**
+         * @experimental
+         */
         export interface ReportingApiEndpointsChangedForOriginEvent {
             /**
              * Origin of the document(s) which configured the endpoints.
@@ -13301,6 +13718,7 @@ export namespace Protocol {
 
     /**
      * This domain provides various functionality related to drawing atop the inspected page.
+     * @experimental
      */
     export namespace Overlay {
 
@@ -13352,6 +13770,7 @@ export namespace Protocol {
             gridBorderColor?: DOM.RGBA;
             /**
              * The cell border color (default: transparent). Deprecated, please use rowLineColor and columnLineColor instead.
+             * @deprecated
              */
             cellBorderColor?: DOM.RGBA;
             /**
@@ -13368,6 +13787,7 @@ export namespace Protocol {
             gridBorderDash?: boolean;
             /**
              * Whether the cell border is dashed (default: false). Deprecated, please us rowLineDash and columnLineDash instead.
+             * @deprecated
              */
             cellBorderDash?: boolean;
             /**
@@ -13474,7 +13894,7 @@ export namespace Protocol {
              */
             color?: DOM.RGBA;
             /**
-             * The line pattern (default: solid) (LineStylePattern enum)
+             * The line pattern (default: solid)
              */
             pattern?: ('dashed' | 'dotted');
         }
@@ -14046,13 +14466,18 @@ export namespace Protocol {
 
         /**
          * Indicates whether a frame has been identified as an ad.
+         * @experimental
          */
         export type AdFrameType = ('none' | 'child' | 'root');
 
+        /**
+         * @experimental
+         */
         export type AdFrameExplanation = ('ParentIsAd' | 'CreatedByAdScript' | 'MatchedBlockingRule');
 
         /**
          * Indicates whether a frame has been identified as an ad and why.
+         * @experimental
          */
         export interface AdFrameStatus {
             adFrameType: AdFrameType;
@@ -14062,6 +14487,7 @@ export namespace Protocol {
         /**
          * Identifies the script which caused a script or frame to be labelled as an
          * ad.
+         * @experimental
          */
         export interface AdScriptId {
             /**
@@ -14079,6 +14505,7 @@ export namespace Protocol {
          * Encapsulates the script ancestry and the root script filterlist rule that
          * caused the frame to be labelled as an ad. Only created when `ancestryChain`
          * is not empty.
+         * @experimental
          */
         export interface AdScriptAncestry {
             /**
@@ -14098,32 +14525,45 @@ export namespace Protocol {
 
         /**
          * Indicates whether the frame is a secure context and why it is the case.
+         * @experimental
          */
         export type SecureContextType = ('Secure' | 'SecureLocalhost' | 'InsecureScheme' | 'InsecureAncestor');
 
         /**
          * Indicates whether the frame is cross-origin isolated and why it is the case.
+         * @experimental
          */
         export type CrossOriginIsolatedContextType = ('Isolated' | 'NotIsolated' | 'NotIsolatedFeatureDisabled');
 
+        /**
+         * @experimental
+         */
         export type GatedAPIFeatures = ('SharedArrayBuffers' | 'SharedArrayBuffersTransferAllowed' | 'PerformanceMeasureMemory' | 'PerformanceProfile');
 
         /**
          * All Permissions Policy features. This enum should match the one defined
          * in services/network/public/cpp/permissions_policy/permissions_policy_features.json5.
+         * @experimental
          */
         export type PermissionsPolicyFeature = ('accelerometer' | 'all-screens-capture' | 'ambient-light-sensor' | 'aria-notify' | 'attribution-reporting' | 'autoplay' | 'bluetooth' | 'browsing-topics' | 'camera' | 'captured-surface-control' | 'ch-dpr' | 'ch-device-memory' | 'ch-downlink' | 'ch-ect' | 'ch-prefers-color-scheme' | 'ch-prefers-reduced-motion' | 'ch-prefers-reduced-transparency' | 'ch-rtt' | 'ch-save-data' | 'ch-ua' | 'ch-ua-arch' | 'ch-ua-bitness' | 'ch-ua-high-entropy-values' | 'ch-ua-platform' | 'ch-ua-model' | 'ch-ua-mobile' | 'ch-ua-form-factors' | 'ch-ua-full-version' | 'ch-ua-full-version-list' | 'ch-ua-platform-version' | 'ch-ua-wow64' | 'ch-viewport-height' | 'ch-viewport-width' | 'ch-width' | 'clipboard-read' | 'clipboard-write' | 'compute-pressure' | 'controlled-frame' | 'cross-origin-isolated' | 'deferred-fetch' | 'deferred-fetch-minimal' | 'device-attributes' | 'digital-credentials-get' | 'direct-sockets' | 'direct-sockets-private' | 'display-capture' | 'document-domain' | 'encrypted-media' | 'execution-while-out-of-viewport' | 'execution-while-not-rendered' | 'fenced-unpartitioned-storage-read' | 'focus-without-user-activation' | 'fullscreen' | 'frobulate' | 'gamepad' | 'geolocation' | 'gyroscope' | 'hid' | 'identity-credentials-get' | 'idle-detection' | 'interest-cohort' | 'join-ad-interest-group' | 'keyboard-map' | 'language-detector' | 'language-model' | 'local-fonts' | 'local-network-access' | 'magnetometer' | 'media-playback-while-not-visible' | 'microphone' | 'midi' | 'on-device-speech-recognition' | 'otp-credentials' | 'payment' | 'picture-in-picture' | 'popins' | 'private-aggregation' | 'private-state-token-issuance' | 'private-state-token-redemption' | 'publickey-credentials-create' | 'publickey-credentials-get' | 'record-ad-auction-events' | 'rewriter' | 'run-ad-auction' | 'screen-wake-lock' | 'serial' | 'shared-autofill' | 'shared-storage' | 'shared-storage-select-url' | 'smart-card' | 'speaker-selection' | 'storage-access' | 'sub-apps' | 'summarizer' | 'sync-xhr' | 'translator' | 'unload' | 'usb' | 'usb-unrestricted' | 'vertical-scroll' | 'web-app-installation' | 'web-printing' | 'web-share' | 'window-management' | 'writer' | 'xr-spatial-tracking');
 
         /**
          * Reason for a permissions policy feature to be disabled.
+         * @experimental
          */
         export type PermissionsPolicyBlockReason = ('Header' | 'IframeAttribute' | 'InFencedFrameTree' | 'InIsolatedApp');
 
+        /**
+         * @experimental
+         */
         export interface PermissionsPolicyBlockLocator {
             frameId: FrameId;
             blockReason: PermissionsPolicyBlockReason;
         }
 
+        /**
+         * @experimental
+         */
         export interface PermissionsPolicyFeatureState {
             feature: PermissionsPolicyFeature;
             allowed: boolean;
@@ -14133,16 +14573,24 @@ export namespace Protocol {
         /**
          * Origin Trial(https://www.chromium.org/blink/origin-trials) support.
          * Status for an Origin Trial token.
+         * @experimental
          */
         export type OriginTrialTokenStatus = ('Success' | 'NotSupported' | 'Insecure' | 'Expired' | 'WrongOrigin' | 'InvalidSignature' | 'Malformed' | 'WrongVersion' | 'FeatureDisabled' | 'TokenDisabled' | 'FeatureDisabledForUser' | 'UnknownTrial');
 
         /**
          * Status for an Origin Trial.
+         * @experimental
          */
         export type OriginTrialStatus = ('Enabled' | 'ValidTokenNotProvided' | 'OSNotSupported' | 'TrialNotAllowed');
 
+        /**
+         * @experimental
+         */
         export type OriginTrialUsageRestriction = ('None' | 'Subset');
 
+        /**
+         * @experimental
+         */
         export interface OriginTrialToken {
             origin: string;
             matchSubDomains: boolean;
@@ -14152,6 +14600,9 @@ export namespace Protocol {
             usageRestriction: OriginTrialUsageRestriction;
         }
 
+        /**
+         * @experimental
+         */
         export interface OriginTrialTokenWithStatus {
             rawTokenText: string;
             /**
@@ -14162,6 +14613,9 @@ export namespace Protocol {
             status: OriginTrialTokenStatus;
         }
 
+        /**
+         * @experimental
+         */
         export interface OriginTrial {
             trialName: string;
             status: OriginTrialStatus;
@@ -14170,6 +14624,7 @@ export namespace Protocol {
 
         /**
          * Additional information about the frame document's security origin.
+         * @experimental
          */
         export interface SecurityOriginDetails {
             /**
@@ -14206,6 +14661,7 @@ export namespace Protocol {
             url: string;
             /**
              * Frame document's URL fragment including the '#'.
+             * @experimental
              */
             urlFragment?: string;
             /**
@@ -14213,6 +14669,7 @@ export namespace Protocol {
              * Extracted from the Frame's url.
              * Example URLs: http://www.google.com/file.html -> "google.com"
              *               http://a.b.co.uk/file.html      -> "b.co.uk"
+             * @experimental
              */
             domainAndRegistry: string;
             /**
@@ -14221,6 +14678,7 @@ export namespace Protocol {
             securityOrigin: string;
             /**
              * Additional details about the frame document's security origin.
+             * @experimental
              */
             securityOriginDetails?: SecurityOriginDetails;
             /**
@@ -14229,28 +14687,34 @@ export namespace Protocol {
             mimeType: string;
             /**
              * If the frame failed to load, this contains the URL that could not be loaded. Note that unlike url above, this URL may contain a fragment.
+             * @experimental
              */
             unreachableUrl?: string;
             /**
              * Indicates whether this frame was tagged as an ad and why.
+             * @experimental
              */
             adFrameStatus?: AdFrameStatus;
             /**
              * Indicates whether the main document is a secure context and explains why that is the case.
+             * @experimental
              */
             secureContextType: SecureContextType;
             /**
              * Indicates whether this is a cross origin isolated context.
+             * @experimental
              */
             crossOriginIsolatedContextType: CrossOriginIsolatedContextType;
             /**
              * Indicated which gated APIs / features are available.
+             * @experimental
              */
             gatedAPIFeatures: GatedAPIFeatures[];
         }
 
         /**
          * Information about the Resource on the page.
+         * @experimental
          */
         export interface FrameResource {
             /**
@@ -14285,6 +14749,7 @@ export namespace Protocol {
 
         /**
          * Information about the Frame hierarchy along with their cached resources.
+         * @experimental
          */
         export interface FrameResourceTree {
             /**
@@ -14353,6 +14818,7 @@ export namespace Protocol {
 
         /**
          * Screencast frame metadata.
+         * @experimental
          */
         export interface ScreencastFrameMetadata {
             /**
@@ -14414,6 +14880,7 @@ export namespace Protocol {
 
         /**
          * Parsed app manifest properties.
+         * @experimental
          */
         export interface AppManifestParsedProperties {
             /**
@@ -14510,6 +14977,7 @@ export namespace Protocol {
 
         /**
          * Generic font families collection.
+         * @experimental
          */
         export interface FontFamilies {
             /**
@@ -14544,6 +15012,7 @@ export namespace Protocol {
 
         /**
          * Font families collection for a script.
+         * @experimental
          */
         export interface ScriptFontFamilies {
             /**
@@ -14558,6 +15027,7 @@ export namespace Protocol {
 
         /**
          * Default font sizes.
+         * @experimental
          */
         export interface FontSizes {
             /**
@@ -14570,10 +15040,19 @@ export namespace Protocol {
             fixed?: integer;
         }
 
+        /**
+         * @experimental
+         */
         export type ClientNavigationReason = ('anchorClick' | 'formSubmissionGet' | 'formSubmissionPost' | 'httpHeaderRefresh' | 'initialFrameNavigation' | 'metaTagRefresh' | 'other' | 'pageBlockInterstitial' | 'reload' | 'scriptInitiated');
 
+        /**
+         * @experimental
+         */
         export type ClientNavigationDisposition = ('currentTab' | 'newTab' | 'newWindow' | 'download');
 
+        /**
+         * @experimental
+         */
         export interface InstallabilityErrorArgument {
             /**
              * Argument name (e.g. name:'minimum-icon-size-in-pixels').
@@ -14587,6 +15066,7 @@ export namespace Protocol {
 
         /**
          * The installability error
+         * @experimental
          */
         export interface InstallabilityError {
             /**
@@ -14601,11 +15081,13 @@ export namespace Protocol {
 
         /**
          * The referring-policy used for the navigation.
+         * @experimental
          */
         export type ReferrerPolicy = ('noReferrer' | 'noReferrerWhenDowngrade' | 'origin' | 'originWhenCrossOrigin' | 'sameOrigin' | 'strictOrigin' | 'strictOriginWhenCrossOrigin' | 'unsafeUrl');
 
         /**
          * Per-script compilation cache parameters for `Page.produceCompilationCache`
+         * @experimental
          */
         export interface CompilationCacheParams {
             /**
@@ -14619,11 +15101,17 @@ export namespace Protocol {
             eager?: boolean;
         }
 
+        /**
+         * @experimental
+         */
         export interface FileFilter {
             name?: string;
             accepts?: string[];
         }
 
+        /**
+         * @experimental
+         */
         export interface FileHandler {
             action: string;
             name: string;
@@ -14641,6 +15129,7 @@ export namespace Protocol {
 
         /**
          * The image definition used in both icon and screenshot.
+         * @experimental
          */
         export interface ImageResource {
             /**
@@ -14652,20 +15141,32 @@ export namespace Protocol {
             type?: string;
         }
 
+        /**
+         * @experimental
+         */
         export interface LaunchHandler {
             clientMode: string;
         }
 
+        /**
+         * @experimental
+         */
         export interface ProtocolHandler {
             protocol: string;
             url: string;
         }
 
+        /**
+         * @experimental
+         */
         export interface RelatedApplication {
             id?: string;
             url: string;
         }
 
+        /**
+         * @experimental
+         */
         export interface ScopeExtension {
             /**
              * Instead of using tuple, this field always returns the serialized string
@@ -14675,12 +15176,18 @@ export namespace Protocol {
             hasOriginWildcard: boolean;
         }
 
+        /**
+         * @experimental
+         */
         export interface Screenshot {
             image: ImageResource;
             formFactor: string;
             label?: string;
         }
 
+        /**
+         * @experimental
+         */
         export interface ShareTarget {
             action: string;
             method: string;
@@ -14694,11 +15201,17 @@ export namespace Protocol {
             files?: FileFilter[];
         }
 
+        /**
+         * @experimental
+         */
         export interface Shortcut {
             name: string;
             url: string;
         }
 
+        /**
+         * @experimental
+         */
         export interface WebAppManifest {
             backgroundColor?: string;
             /**
@@ -14751,19 +15264,25 @@ export namespace Protocol {
 
         /**
          * The type of a frameNavigated event.
+         * @experimental
          */
         export type NavigationType = ('Navigation' | 'BackForwardCacheRestore');
 
         /**
          * List of not restored reasons for back-forward cache.
+         * @experimental
          */
         export type BackForwardCacheNotRestoredReason = ('NotPrimaryMainFrame' | 'BackForwardCacheDisabled' | 'RelatedActiveContentsExist' | 'HTTPStatusNotOK' | 'SchemeNotHTTPOrHTTPS' | 'Loading' | 'WasGrantedMediaAccess' | 'DisableForRenderFrameHostCalled' | 'DomainNotAllowed' | 'HTTPMethodNotGET' | 'SubframeIsNavigating' | 'Timeout' | 'CacheLimit' | 'JavaScriptExecution' | 'RendererProcessKilled' | 'RendererProcessCrashed' | 'SchedulerTrackedFeatureUsed' | 'ConflictingBrowsingInstance' | 'CacheFlushed' | 'ServiceWorkerVersionActivation' | 'SessionRestored' | 'ServiceWorkerPostMessage' | 'EnteredBackForwardCacheBeforeServiceWorkerHostAdded' | 'RenderFrameHostReused_SameSite' | 'RenderFrameHostReused_CrossSite' | 'ServiceWorkerClaim' | 'IgnoreEventAndEvict' | 'HaveInnerContents' | 'TimeoutPuttingInCache' | 'BackForwardCacheDisabledByLowMemory' | 'BackForwardCacheDisabledByCommandLine' | 'NetworkRequestDatapipeDrainedAsBytesConsumer' | 'NetworkRequestRedirected' | 'NetworkRequestTimeout' | 'NetworkExceedsBufferLimit' | 'NavigationCancelledWhileRestoring' | 'NotMostRecentNavigationEntry' | 'BackForwardCacheDisabledForPrerender' | 'UserAgentOverrideDiffers' | 'ForegroundCacheLimit' | 'BrowsingInstanceNotSwapped' | 'BackForwardCacheDisabledForDelegate' | 'UnloadHandlerExistsInMainFrame' | 'UnloadHandlerExistsInSubFrame' | 'ServiceWorkerUnregistration' | 'CacheControlNoStore' | 'CacheControlNoStoreCookieModified' | 'CacheControlNoStoreHTTPOnlyCookieModified' | 'NoResponseHead' | 'Unknown' | 'ActivationNavigationsDisallowedForBug1234857' | 'ErrorDocument' | 'FencedFramesEmbedder' | 'CookieDisabled' | 'HTTPAuthRequired' | 'CookieFlushed' | 'BroadcastChannelOnMessage' | 'WebViewSettingsChanged' | 'WebViewJavaScriptObjectChanged' | 'WebViewMessageListenerInjected' | 'WebViewSafeBrowsingAllowlistChanged' | 'WebViewDocumentStartJavascriptChanged' | 'WebSocket' | 'WebTransport' | 'WebRTC' | 'MainResourceHasCacheControlNoStore' | 'MainResourceHasCacheControlNoCache' | 'SubresourceHasCacheControlNoStore' | 'SubresourceHasCacheControlNoCache' | 'ContainsPlugins' | 'DocumentLoaded' | 'OutstandingNetworkRequestOthers' | 'RequestedMIDIPermission' | 'RequestedAudioCapturePermission' | 'RequestedVideoCapturePermission' | 'RequestedBackForwardCacheBlockedSensors' | 'RequestedBackgroundWorkPermission' | 'BroadcastChannel' | 'WebXR' | 'SharedWorker' | 'SharedWorkerMessage' | 'WebLocks' | 'WebHID' | 'WebShare' | 'RequestedStorageAccessGrant' | 'WebNfc' | 'OutstandingNetworkRequestFetch' | 'OutstandingNetworkRequestXHR' | 'AppBanner' | 'Printing' | 'WebDatabase' | 'PictureInPicture' | 'SpeechRecognizer' | 'IdleManager' | 'PaymentManager' | 'SpeechSynthesis' | 'KeyboardLock' | 'WebOTPService' | 'OutstandingNetworkRequestDirectSocket' | 'InjectedJavascript' | 'InjectedStyleSheet' | 'KeepaliveRequest' | 'IndexedDBEvent' | 'Dummy' | 'JsNetworkRequestReceivedCacheControlNoStoreResource' | 'WebRTCSticky' | 'WebTransportSticky' | 'WebSocketSticky' | 'SmartCard' | 'LiveMediaStreamTrack' | 'UnloadHandler' | 'ParserAborted' | 'ContentSecurityHandler' | 'ContentWebAuthenticationAPI' | 'ContentFileChooser' | 'ContentSerial' | 'ContentFileSystemAccess' | 'ContentMediaDevicesDispatcherHost' | 'ContentWebBluetooth' | 'ContentWebUSB' | 'ContentMediaSessionService' | 'ContentScreenReader' | 'ContentDiscarded' | 'EmbedderPopupBlockerTabHelper' | 'EmbedderSafeBrowsingTriggeredPopupBlocker' | 'EmbedderSafeBrowsingThreatDetails' | 'EmbedderAppBannerManager' | 'EmbedderDomDistillerViewerSource' | 'EmbedderDomDistillerSelfDeletingRequestDelegate' | 'EmbedderOomInterventionTabHelper' | 'EmbedderOfflinePage' | 'EmbedderChromePasswordManagerClientBindCredentialManager' | 'EmbedderPermissionRequestManager' | 'EmbedderModalDialog' | 'EmbedderExtensions' | 'EmbedderExtensionMessaging' | 'EmbedderExtensionMessagingForOpenPort' | 'EmbedderExtensionSentMessageToCachedFrame' | 'RequestedByWebViewClient' | 'PostMessageByWebViewClient' | 'CacheControlNoStoreDeviceBoundSessionTerminated' | 'CacheLimitPrunedOnModerateMemoryPressure' | 'CacheLimitPrunedOnCriticalMemoryPressure');
 
         /**
          * Types of not restored reasons for back-forward cache.
+         * @experimental
          */
         export type BackForwardCacheNotRestoredReasonType = ('SupportPending' | 'PageSupportNeeded' | 'Circumstantial');
 
+        /**
+         * @experimental
+         */
         export interface BackForwardCacheBlockingDetails {
             /**
              * Url of the file where blockage happened. Optional because of tests.
@@ -14783,6 +15302,9 @@ export namespace Protocol {
             columnNumber: integer;
         }
 
+        /**
+         * @experimental
+         */
         export interface BackForwardCacheNotRestoredExplanation {
             /**
              * Type of the reason
@@ -14801,6 +15323,9 @@ export namespace Protocol {
             details?: BackForwardCacheBlockingDetails[];
         }
 
+        /**
+         * @experimental
+         */
         export interface BackForwardCacheNotRestoredExplanationTree {
             /**
              * URL of each frame
@@ -14833,16 +15358,19 @@ export namespace Protocol {
              * If specified, creates an isolated world with the given name and evaluates given script in it.
              * This world name will be used as the ExecutionContextDescription::name when the corresponding
              * event is emitted.
+             * @experimental
              */
             worldName?: string;
             /**
              * Specifies whether command line API should be available to the script, defaults
              * to false.
+             * @experimental
              */
             includeCommandLineAPI?: boolean;
             /**
              * If true, runs the script immediately on existing execution contexts or worlds.
              * Default: false.
+             * @experimental
              */
             runImmediately?: boolean;
         }
@@ -14862,7 +15390,7 @@ export namespace Protocol {
 
         export interface CaptureScreenshotRequest {
             /**
-             * Image compression format (defaults to png). (CaptureScreenshotRequestFormat enum)
+             * Image compression format (defaults to png).
              */
             format?: ('jpeg' | 'png' | 'webp');
             /**
@@ -14875,14 +15403,17 @@ export namespace Protocol {
             clip?: Viewport;
             /**
              * Capture the screenshot from the surface, rather than the view. Defaults to true.
+             * @experimental
              */
             fromSurface?: boolean;
             /**
              * Capture the screenshot beyond the viewport. Defaults to false.
+             * @experimental
              */
             captureBeyondViewport?: boolean;
             /**
              * Optimize image encoding for speed, not for resulting size (defaults to false)
+             * @experimental
              */
             optimizeForSpeed?: boolean;
         }
@@ -14900,7 +15431,7 @@ export namespace Protocol {
 
         export interface CaptureSnapshotRequest {
             /**
-             * Format (defaults to mhtml). (CaptureSnapshotRequestFormat enum)
+             * Format (defaults to mhtml).
              */
             format?: ('mhtml');
         }
@@ -14950,6 +15481,7 @@ export namespace Protocol {
             /**
              * If true, the `Page.fileChooserOpened` event will be emitted regardless of the state set by
              * `Page.setInterceptFileChooserDialog` command (default: false).
+             * @experimental
              */
             enableFileChooserOpenedEvent?: boolean;
         }
@@ -14970,8 +15502,13 @@ export namespace Protocol {
             data?: string;
             /**
              * Parsed manifest properties. Deprecated, use manifest instead.
+             * @deprecated
+             * @experimental
              */
             parsed?: AppManifestParsedProperties;
+            /**
+             * @experimental
+             */
             manifest: WebAppManifest;
         }
 
@@ -15019,14 +15556,17 @@ export namespace Protocol {
         export interface GetLayoutMetricsResponse {
             /**
              * Deprecated metrics relating to the layout viewport. Is in device pixels. Use `cssLayoutViewport` instead.
+             * @deprecated
              */
             layoutViewport: LayoutViewport;
             /**
              * Deprecated metrics relating to the visual viewport. Is in device pixels. Use `cssVisualViewport` instead.
+             * @deprecated
              */
             visualViewport: VisualViewport;
             /**
              * Deprecated size of scrollable area. Is in DP. Use `cssContentSize` instead.
+             * @deprecated
              */
             contentSize: DOM.Rect;
             /**
@@ -15114,6 +15654,7 @@ export namespace Protocol {
             frameId?: FrameId;
             /**
              * Referrer-policy used for the navigation.
+             * @experimental
              */
             referrerPolicy?: ReferrerPolicy;
         }
@@ -15134,6 +15675,7 @@ export namespace Protocol {
             errorText?: string;
             /**
              * Whether the navigation resulted in a download.
+             * @experimental
              */
             isDownload?: boolean;
         }
@@ -15224,15 +15766,18 @@ export namespace Protocol {
              */
             preferCSSPageSize?: boolean;
             /**
-             * return as stream (PrintToPDFRequestTransferMode enum)
+             * return as stream
+             * @experimental
              */
             transferMode?: ('ReturnAsBase64' | 'ReturnAsStream');
             /**
              * Whether or not to generate tagged (accessible) PDF. Defaults to embedder choice.
+             * @experimental
              */
             generateTaggedPDF?: boolean;
             /**
              * Whether or not to embed the document outline into the PDF.
+             * @experimental
              */
             generateDocumentOutline?: boolean;
         }
@@ -15244,6 +15789,7 @@ export namespace Protocol {
             data: string;
             /**
              * A handle of the stream that holds resulting PDF data.
+             * @experimental
              */
             stream?: IO.StreamHandle;
         }
@@ -15262,6 +15808,7 @@ export namespace Protocol {
              * If set, an error will be thrown if the target page's main frame's
              * loader id does not match the provided id. This prevents accidentally
              * reloading an unintended target in case there's a racing navigation.
+             * @experimental
              */
             loaderId?: Network.LoaderId;
         }
@@ -15446,7 +15993,7 @@ export namespace Protocol {
         export interface SetDownloadBehaviorRequest {
             /**
              * Whether to allow all or deny all download requests, or use default Chrome behavior if
-             * available (otherwise deny). (SetDownloadBehaviorRequestBehavior enum)
+             * available (otherwise deny).
              */
             behavior: ('deny' | 'allow' | 'default');
             /**
@@ -15488,7 +16035,7 @@ export namespace Protocol {
              */
             enabled: boolean;
             /**
-             * Touch/gesture events configuration. Default: current platform. (SetTouchEmulationEnabledRequestConfiguration enum)
+             * Touch/gesture events configuration. Default: current platform.
              */
             configuration?: ('mobile' | 'desktop');
         }
@@ -15500,7 +16047,7 @@ export namespace Protocol {
 
         export interface StartScreencastRequest {
             /**
-             * Image compression format. (StartScreencastRequestFormat enum)
+             * Image compression format.
              */
             format?: ('jpeg' | 'png');
             /**
@@ -15528,7 +16075,7 @@ export namespace Protocol {
 
         export interface SetWebLifecycleStateRequest {
             /**
-             * Target lifecycle state (SetWebLifecycleStateRequestState enum)
+             * Target lifecycle state
              */
             state: ('frozen' | 'active');
         }
@@ -15554,9 +16101,6 @@ export namespace Protocol {
         }
 
         export interface SetSPCTransactionModeRequest {
-            /**
-             *  (SetSPCTransactionModeRequestMode enum)
-             */
             mode: ('none' | 'autoAccept' | 'autoChooseToAuthAnotherWay' | 'autoReject' | 'autoOptOut');
         }
 
@@ -15567,9 +16111,6 @@ export namespace Protocol {
         }
 
         export interface SetRPHRegistrationModeRequest {
-            /**
-             *  (SetRPHRegistrationModeRequestMode enum)
-             */
             mode: ('none' | 'autoAccept' | 'autoReject');
         }
 
@@ -15590,6 +16131,7 @@ export namespace Protocol {
              * If true, cancels the dialog by emitting relevant events (if any)
              * in addition to not showing it if the interception is enabled
              * (default: false).
+             * @experimental
              */
             cancel?: boolean;
         }
@@ -15613,14 +16155,16 @@ export namespace Protocol {
         export interface FileChooserOpenedEvent {
             /**
              * Id of the frame containing input node.
+             * @experimental
              */
             frameId: FrameId;
             /**
-             * Input mode. (FileChooserOpenedEventMode enum)
+             * Input mode.
              */
             mode: ('selectSingle' | 'selectMultiple');
             /**
              * Input node id. Only present for file choosers opened via an `<input type="file">` element.
+             * @experimental
              */
             backendNodeId?: DOM.BackendNodeId;
         }
@@ -15645,6 +16189,7 @@ export namespace Protocol {
 
         /**
          * Fired when frame no longer has a scheduled navigation.
+         * @deprecated
          */
         export interface FrameClearedScheduledNavigationEvent {
             /**
@@ -15667,7 +16212,7 @@ export namespace Protocol {
              */
             frameId: FrameId;
             /**
-             *  (FrameDetachedEventReason enum)
+             * @experimental
              */
             reason: ('remove' | 'swap');
         }
@@ -15675,6 +16220,7 @@ export namespace Protocol {
         /**
          * Fired before frame subtree is detached. Emitted before any frame of the
          * subtree is actually detached.
+         * @experimental
          */
         export interface FrameSubtreeWillBeDetachedEvent {
             /**
@@ -15691,11 +16237,15 @@ export namespace Protocol {
              * Frame object.
              */
             frame: Frame;
+            /**
+             * @experimental
+             */
             type: NavigationType;
         }
 
         /**
          * Fired when opening document to write to.
+         * @experimental
          */
         export interface DocumentOpenedEvent {
             /**
@@ -15723,6 +16273,7 @@ export namespace Protocol {
          * can be fired for a single navigation, for example, when a same-document
          * navigation becomes a cross-document navigation (such as in the case of a
          * frameset).
+         * @experimental
          */
         export interface FrameStartedNavigatingEvent {
             /**
@@ -15740,15 +16291,13 @@ export namespace Protocol {
              * navigation.
              */
             loaderId: Network.LoaderId;
-            /**
-             *  (FrameStartedNavigatingEventNavigationType enum)
-             */
             navigationType: ('reload' | 'reloadBypassingCache' | 'restore' | 'restoreWithPost' | 'historySameDocument' | 'historyDifferentDocument' | 'sameDocument' | 'differentDocument');
         }
 
         /**
          * Fired when a renderer-initiated navigation is requested.
          * Navigation may still be cancelled after the event is issued.
+         * @experimental
          */
         export interface FrameRequestedNavigationEvent {
             /**
@@ -15771,6 +16320,7 @@ export namespace Protocol {
 
         /**
          * Fired when frame schedules a potential navigation.
+         * @deprecated
          */
         export interface FrameScheduledNavigationEvent {
             /**
@@ -15794,6 +16344,7 @@ export namespace Protocol {
 
         /**
          * Fired when frame has started loading.
+         * @experimental
          */
         export interface FrameStartedLoadingEvent {
             /**
@@ -15804,6 +16355,7 @@ export namespace Protocol {
 
         /**
          * Fired when frame has stopped loading.
+         * @experimental
          */
         export interface FrameStoppedLoadingEvent {
             /**
@@ -15815,6 +16367,8 @@ export namespace Protocol {
         /**
          * Fired when page is about to start a download.
          * Deprecated. Use Browser.downloadWillBegin instead.
+         * @deprecated
+         * @experimental
          */
         export interface DownloadWillBeginEvent {
             /**
@@ -15844,6 +16398,8 @@ export namespace Protocol {
         /**
          * Fired when download makes progress. Last call has |done| == true.
          * Deprecated. Use Browser.downloadProgress instead.
+         * @deprecated
+         * @experimental
          */
         export interface DownloadProgressEvent {
             /**
@@ -15859,7 +16415,7 @@ export namespace Protocol {
              */
             receivedBytes: number;
             /**
-             * Download status. (DownloadProgressEventState enum)
+             * Download status.
              */
             state: ('inProgress' | 'completed' | 'canceled');
         }
@@ -15871,6 +16427,7 @@ export namespace Protocol {
         export interface JavascriptDialogClosedEvent {
             /**
              * Frame id.
+             * @experimental
              */
             frameId: FrameId;
             /**
@@ -15894,6 +16451,7 @@ export namespace Protocol {
             url: string;
             /**
              * Frame id.
+             * @experimental
              */
             frameId: FrameId;
             /**
@@ -15938,6 +16496,7 @@ export namespace Protocol {
          * not assume any ordering with the Page.frameNavigated event. This event is fired only for
          * main-frame history navigation where the document changes (non-same-document navigations),
          * when bfcache navigation fails.
+         * @experimental
          */
         export interface BackForwardCacheNotUsedEvent {
             /**
@@ -15970,6 +16529,7 @@ export namespace Protocol {
 
         /**
          * Fired when same-document navigation happens, e.g. due to history API usage or anchor navigation.
+         * @experimental
          */
         export interface NavigatedWithinDocumentEvent {
             /**
@@ -15981,13 +16541,14 @@ export namespace Protocol {
              */
             url: string;
             /**
-             * Navigation type (NavigatedWithinDocumentEventNavigationType enum)
+             * Navigation type
              */
             navigationType: ('fragment' | 'historyApi' | 'other');
         }
 
         /**
          * Compressed image data requested by the `startScreencast`.
+         * @experimental
          */
         export interface ScreencastFrameEvent {
             /**
@@ -16006,6 +16567,7 @@ export namespace Protocol {
 
         /**
          * Fired when the page with currently enabled screencast was shown or hidden `.
+         * @experimental
          */
         export interface ScreencastVisibilityChangedEvent {
             /**
@@ -16040,6 +16602,7 @@ export namespace Protocol {
         /**
          * Issued for every compilation cache generated. Is only available
          * if Page.setGenerateCompilationCache is enabled.
+         * @experimental
          */
         export interface CompilationCacheProducedEvent {
             url: string;
@@ -16073,7 +16636,7 @@ export namespace Protocol {
 
         export interface EnableRequest {
             /**
-             * Time domain to use for collecting and reporting duration metrics. (EnableRequestTimeDomain enum)
+             * Time domain to use for collecting and reporting duration metrics.
              */
             timeDomain?: ('timeTicks' | 'threadTicks');
         }
@@ -16085,7 +16648,7 @@ export namespace Protocol {
 
         export interface SetTimeDomainRequest {
             /**
-             * Time domain (SetTimeDomainRequestTimeDomain enum)
+             * Time domain
              */
             timeDomain: ('timeTicks' | 'threadTicks');
         }
@@ -16115,6 +16678,7 @@ export namespace Protocol {
     /**
      * Reporting of performance timeline events, as specified in
      * https://w3c.github.io/performance-timeline/#dom-performanceobserver.
+     * @experimental
      */
     export namespace PerformanceTimeline {
 
@@ -16226,6 +16790,7 @@ export namespace Protocol {
 
         /**
          * Details about the security state of the page certificate.
+         * @experimental
          */
         export interface CertificateSecurityState {
             /**
@@ -16302,8 +16867,14 @@ export namespace Protocol {
             obsoleteSslSignature: boolean;
         }
 
+        /**
+         * @experimental
+         */
         export type SafetyTipStatus = ('badReputation' | 'lookalike');
 
+        /**
+         * @experimental
+         */
         export interface SafetyTipInfo {
             /**
              * Describes whether the page triggers any safety tips or reputation warnings. Default is unknown.
@@ -16317,6 +16888,7 @@ export namespace Protocol {
 
         /**
          * Security state information about the page.
+         * @experimental
          */
         export interface VisibleSecurityState {
             /**
@@ -16373,6 +16945,7 @@ export namespace Protocol {
 
         /**
          * Information about insecure content on the page.
+         * @deprecated
          */
         export interface InsecureContentStatus {
             /**
@@ -16441,6 +17014,7 @@ export namespace Protocol {
          * handled with the `handleCertificateError` command. Note: this event does not fire if the
          * certificate error has been allowed internally. Only one client per target should override
          * certificate errors at the same time.
+         * @deprecated
          */
         export interface CertificateErrorEvent {
             /**
@@ -16459,6 +17033,7 @@ export namespace Protocol {
 
         /**
          * The security state of the page changed.
+         * @experimental
          */
         export interface VisibleSecurityStateChangedEvent {
             /**
@@ -16469,6 +17044,7 @@ export namespace Protocol {
 
         /**
          * The security state of the page changed. No longer being sent.
+         * @deprecated
          */
         export interface SecurityStateChangedEvent {
             /**
@@ -16477,24 +17053,31 @@ export namespace Protocol {
             securityState: SecurityState;
             /**
              * True if the page was loaded over cryptographic transport such as HTTPS.
+             * @deprecated
              */
             schemeIsCryptographic: boolean;
             /**
              * Previously a list of explanations for the security state. Now always
              * empty.
+             * @deprecated
              */
             explanations: SecurityStateExplanation[];
             /**
              * Information about insecure content on the page.
+             * @deprecated
              */
             insecureContentStatus: InsecureContentStatus;
             /**
              * Overrides user-visible description of the state. Always omitted.
+             * @deprecated
              */
             summary?: string;
         }
     }
 
+    /**
+     * @experimental
+     */
     export namespace ServiceWorker {
 
         export type RegistrationID = string;
@@ -16603,6 +17186,9 @@ export namespace Protocol {
         }
     }
 
+    /**
+     * @experimental
+     */
     export namespace Storage {
 
         export type SerializedStorageKey = string;
@@ -16629,6 +17215,7 @@ export namespace Protocol {
         /**
          * Pair of issuer origin and number of available (signed, but not used) Trust
          * Tokens from that issuer.
+         * @experimental
          */
         export interface TrustTokens {
             issuerOrigin: string;
@@ -16868,19 +17455,37 @@ export namespace Protocol {
             durability: StorageBucketsDurability;
         }
 
+        /**
+         * @experimental
+         */
         export type AttributionReportingSourceType = ('navigation' | 'event');
 
+        /**
+         * @experimental
+         */
         export type UnsignedInt64AsBase10 = string;
 
+        /**
+         * @experimental
+         */
         export type UnsignedInt128AsBase16 = string;
 
+        /**
+         * @experimental
+         */
         export type SignedInt64AsBase10 = string;
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingFilterDataEntry {
             key: string;
             values: string[];
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingFilterConfig {
             filterValues: AttributionReportingFilterDataEntry[];
             /**
@@ -16889,16 +17494,25 @@ export namespace Protocol {
             lookbackWindow?: integer;
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingFilterPair {
             filters: AttributionReportingFilterConfig[];
             notFilters: AttributionReportingFilterConfig[];
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingAggregationKeysEntry {
             key: string;
             value: UnsignedInt128AsBase16;
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingEventReportWindows {
             /**
              * duration in seconds
@@ -16910,8 +17524,14 @@ export namespace Protocol {
             ends: integer[];
         }
 
+        /**
+         * @experimental
+         */
         export type AttributionReportingTriggerDataMatching = ('exact' | 'modulus');
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingAggregatableDebugReportingData {
             keyPiece: UnsignedInt128AsBase16;
             /**
@@ -16922,6 +17542,9 @@ export namespace Protocol {
             types: string[];
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingAggregatableDebugReportingConfig {
             /**
              * number instead of integer because not all uint32 can be represented by
@@ -16933,6 +17556,9 @@ export namespace Protocol {
             aggregationCoordinatorOrigin?: string;
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionScopesData {
             values: string[];
             /**
@@ -16943,11 +17569,17 @@ export namespace Protocol {
             maxEventStates: number;
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingNamedBudgetDef {
             name: string;
             budget: integer;
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingSourceRegistration {
             time: Network.TimeSinceEpoch;
             /**
@@ -16983,10 +17615,19 @@ export namespace Protocol {
             eventLevelEpsilon: number;
         }
 
+        /**
+         * @experimental
+         */
         export type AttributionReportingSourceRegistrationResult = ('success' | 'internalError' | 'insufficientSourceCapacity' | 'insufficientUniqueDestinationCapacity' | 'excessiveReportingOrigins' | 'prohibitedByBrowserPolicy' | 'successNoised' | 'destinationReportingLimitReached' | 'destinationGlobalLimitReached' | 'destinationBothLimitsReached' | 'reportingOriginsPerSiteLimitReached' | 'exceedsMaxChannelCapacity' | 'exceedsMaxScopesChannelCapacity' | 'exceedsMaxTriggerStateCardinality' | 'exceedsMaxEventStatesLimit' | 'destinationPerDayReportingLimitReached');
 
+        /**
+         * @experimental
+         */
         export type AttributionReportingSourceRegistrationTimeConfig = ('include' | 'exclude');
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingAggregatableValueDictEntry {
             key: string;
             /**
@@ -16997,11 +17638,17 @@ export namespace Protocol {
             filteringId: UnsignedInt64AsBase10;
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingAggregatableValueEntry {
             values: AttributionReportingAggregatableValueDictEntry[];
             filters: AttributionReportingFilterPair;
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingEventTriggerData {
             data: UnsignedInt64AsBase10;
             priority: SignedInt64AsBase10;
@@ -17009,22 +17656,34 @@ export namespace Protocol {
             filters: AttributionReportingFilterPair;
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingAggregatableTriggerData {
             keyPiece: UnsignedInt128AsBase16;
             sourceKeys: string[];
             filters: AttributionReportingFilterPair;
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingAggregatableDedupKey {
             dedupKey?: UnsignedInt64AsBase10;
             filters: AttributionReportingFilterPair;
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingNamedBudgetCandidate {
             name?: string;
             filters: AttributionReportingFilterPair;
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingTriggerRegistration {
             filters: AttributionReportingFilterPair;
             debugKey?: UnsignedInt64AsBase10;
@@ -17042,14 +17701,24 @@ export namespace Protocol {
             namedBudgets: AttributionReportingNamedBudgetCandidate[];
         }
 
+        /**
+         * @experimental
+         */
         export type AttributionReportingEventLevelResult = ('success' | 'successDroppedLowerPriority' | 'internalError' | 'noCapacityForAttributionDestination' | 'noMatchingSources' | 'deduplicated' | 'excessiveAttributions' | 'priorityTooLow' | 'neverAttributedSource' | 'excessiveReportingOrigins' | 'noMatchingSourceFilterData' | 'prohibitedByBrowserPolicy' | 'noMatchingConfigurations' | 'excessiveReports' | 'falselyAttributedSource' | 'reportWindowPassed' | 'notRegistered' | 'reportWindowNotStarted' | 'noMatchingTriggerData');
 
+        /**
+         * @experimental
+         */
         export type AttributionReportingAggregatableResult = ('success' | 'internalError' | 'noCapacityForAttributionDestination' | 'noMatchingSources' | 'excessiveAttributions' | 'excessiveReportingOrigins' | 'noHistograms' | 'insufficientBudget' | 'insufficientNamedBudget' | 'noMatchingSourceFilterData' | 'notRegistered' | 'prohibitedByBrowserPolicy' | 'deduplicated' | 'reportWindowPassed' | 'excessiveReports');
 
+        /**
+         * @experimental
+         */
         export type AttributionReportingReportResult = ('sent' | 'prohibited' | 'failedToAssemble' | 'expired');
 
         /**
          * A single Related Website Set object.
+         * @experimental
          */
         export interface RelatedWebsiteSet {
             /**
@@ -17594,17 +18263,26 @@ export namespace Protocol {
             bucketId: string;
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingSourceRegisteredEvent {
             registration: AttributionReportingSourceRegistration;
             result: AttributionReportingSourceRegistrationResult;
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingTriggerRegisteredEvent {
             registration: AttributionReportingTriggerRegistration;
             eventLevel: AttributionReportingEventLevelResult;
             aggregatable: AttributionReportingAggregatableResult;
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingReportSentEvent {
             url: string;
             body: any;
@@ -17617,6 +18295,9 @@ export namespace Protocol {
             httpStatusCode?: integer;
         }
 
+        /**
+         * @experimental
+         */
         export interface AttributionReportingVerboseDebugReportSentEvent {
             url: string;
             body?: any[];
@@ -17628,6 +18309,7 @@ export namespace Protocol {
 
     /**
      * The SystemInfo domain defines methods and events for querying low-level system information.
+     * @experimental
      */
     export namespace SystemInfo {
 
@@ -17878,22 +18560,29 @@ export namespace Protocol {
             openerId?: TargetID;
             /**
              * Whether the target has access to the originating window.
+             * @experimental
              */
             canAccessOpener: boolean;
             /**
              * Frame id of originating window (is only set if target has an opener).
+             * @experimental
              */
             openerFrameId?: Page.FrameId;
+            /**
+             * @experimental
+             */
             browserContextId?: Browser.BrowserContextID;
             /**
              * Provides additional details for specific target types. For example, for
              * the type of "page", this may be set to "prerender".
+             * @experimental
              */
             subtype?: string;
         }
 
         /**
          * A filter used by target query/discovery/auto-attach operations.
+         * @experimental
          */
         export interface FilterEntry {
             /**
@@ -17913,9 +18602,13 @@ export namespace Protocol {
          * If filter is not specified, the one assumed is
          * [{type: "browser", exclude: true}, {type: "tab", exclude: true}, {}]
          * (i.e. include everything but `browser` and `tab`).
+         * @experimental
          */
         export type TargetFilter = FilterEntry[];
 
+        /**
+         * @experimental
+         */
         export interface RemoteLocation {
             host: string;
             port: integer;
@@ -17923,6 +18616,7 @@ export namespace Protocol {
 
         /**
          * The state of the target window.
+         * @experimental
          */
         export type WindowState = ('normal' | 'minimized' | 'maximized' | 'fullscreen');
 
@@ -17961,6 +18655,7 @@ export namespace Protocol {
         export interface CloseTargetResponse {
             /**
              * Always set to true. If an error occurs, the response indicates protocol error.
+             * @deprecated
              */
             success: boolean;
         }
@@ -17980,19 +18675,23 @@ export namespace Protocol {
         export interface CreateBrowserContextRequest {
             /**
              * If specified, disposes this context when debugging session disconnects.
+             * @experimental
              */
             disposeOnDetach?: boolean;
             /**
              * Proxy server, similar to the one passed to --proxy-server
+             * @experimental
              */
             proxyServer?: string;
             /**
              * Proxy bypass list, similar to the one passed to --proxy-bypass-list
+             * @experimental
              */
             proxyBypassList?: string;
             /**
              * An optional list of origins to grant unlimited cross-origin access to.
              * Parts of the URL other than those constituting origin are ignored.
+             * @experimental
              */
             originsWithUniversalNetworkAccess?: string[];
         }
@@ -18018,10 +18717,12 @@ export namespace Protocol {
             url: string;
             /**
              * Frame left origin in DIP (requires newWindow to be true or headless shell).
+             * @experimental
              */
             left?: integer;
             /**
              * Frame top origin in DIP (requires newWindow to be true or headless shell).
+             * @experimental
              */
             top?: integer;
             /**
@@ -18039,11 +18740,13 @@ export namespace Protocol {
             windowState?: WindowState;
             /**
              * The browser context to create the page in.
+             * @experimental
              */
             browserContextId?: Browser.BrowserContextID;
             /**
              * Whether BeginFrames for this target will be controlled via DevTools (headless shell only,
              * not supported on MacOS yet, false by default).
+             * @experimental
              */
             enableBeginFrameControl?: boolean;
             /**
@@ -18057,12 +18760,14 @@ export namespace Protocol {
             background?: boolean;
             /**
              * Whether to create the target of type "tab".
+             * @experimental
              */
             forTab?: boolean;
             /**
              * Whether to create a hidden target. The hidden target is observable via protocol, but not
              * present in the tab UI strip. Cannot be created with `forTab: true`, `newWindow: true` or
              * `background: false`. The life-time of the tab is limited to the life-time of the session.
+             * @experimental
              */
             hidden?: boolean;
         }
@@ -18081,6 +18786,7 @@ export namespace Protocol {
             sessionId?: SessionID;
             /**
              * Deprecated.
+             * @deprecated
              */
             targetId?: TargetID;
         }
@@ -18102,6 +18808,7 @@ export namespace Protocol {
              * Only targets matching filter will be reported. If filter is not specified
              * and target discovery is currently enabled, a filter used for target discovery
              * is used for consistency.
+             * @experimental
              */
             filter?: TargetFilter;
         }
@@ -18121,6 +18828,7 @@ export namespace Protocol {
             sessionId?: SessionID;
             /**
              * Deprecated.
+             * @deprecated
              */
             targetId?: TargetID;
         }
@@ -18139,10 +18847,12 @@ export namespace Protocol {
              * Enables "flat" access to the session via specifying sessionId attribute in the commands.
              * We plan to make this the default, deprecate non-flattened mode,
              * and eventually retire it. See crbug.com/991325.
+             * @experimental
              */
             flatten?: boolean;
             /**
              * Only targets matching filter will be attached.
+             * @experimental
              */
             filter?: TargetFilter;
         }
@@ -18156,6 +18866,7 @@ export namespace Protocol {
             waitForDebuggerOnStart: boolean;
             /**
              * Only targets matching filter will be attached.
+             * @experimental
              */
             filter?: TargetFilter;
         }
@@ -18168,6 +18879,7 @@ export namespace Protocol {
             /**
              * Only targets matching filter will be attached. If `discover` is false,
              * `filter` must be omitted or empty.
+             * @experimental
              */
             filter?: TargetFilter;
         }
@@ -18181,6 +18893,7 @@ export namespace Protocol {
 
         /**
          * Issued when attached to target because of auto-attach or `attachToTarget` command.
+         * @experimental
          */
         export interface AttachedToTargetEvent {
             /**
@@ -18194,6 +18907,7 @@ export namespace Protocol {
         /**
          * Issued when detached from target for any reason (including `detachFromTarget` command). Can be
          * issued multiple times per target if multiple sessions have been attached to it.
+         * @experimental
          */
         export interface DetachedFromTargetEvent {
             /**
@@ -18202,6 +18916,7 @@ export namespace Protocol {
             sessionId: SessionID;
             /**
              * Deprecated.
+             * @deprecated
              */
             targetId?: TargetID;
         }
@@ -18218,6 +18933,7 @@ export namespace Protocol {
             message: string;
             /**
              * Deprecated.
+             * @deprecated
              */
             targetId?: TargetID;
         }
@@ -18262,6 +18978,7 @@ export namespace Protocol {
 
     /**
      * The Tethering domain defines methods and events for browser port binding.
+     * @experimental
      */
     export namespace Tethering {
 
@@ -18298,6 +19015,7 @@ export namespace Protocol {
 
         /**
          * Configuration for memory dump. Used only when "memory-infra" category is enabled.
+         * @experimental
          */
         export interface MemoryDumpConfig {
             [key: string]: string;
@@ -18312,24 +19030,29 @@ export namespace Protocol {
 
         export interface TraceConfig {
             /**
-             * Controls how the trace buffer stores data. The default is `recordUntilFull`. (TraceConfigRecordMode enum)
+             * Controls how the trace buffer stores data. The default is `recordUntilFull`.
+             * @experimental
              */
             recordMode?: ('recordUntilFull' | 'recordContinuously' | 'recordAsMuchAsPossible' | 'echoToConsole');
             /**
              * Size of the trace buffer in kilobytes. If not specified or zero is passed, a default value
              * of 200 MB would be used.
+             * @experimental
              */
             traceBufferSizeInKb?: number;
             /**
              * Turns on JavaScript stack sampling.
+             * @experimental
              */
             enableSampling?: boolean;
             /**
              * Turns on system tracing.
+             * @experimental
              */
             enableSystrace?: boolean;
             /**
              * Turns on argument filter.
+             * @experimental
              */
             enableArgumentFilter?: boolean;
             /**
@@ -18342,10 +19065,12 @@ export namespace Protocol {
             excludedCategories?: string[];
             /**
              * Configuration to synthesize the delays in tracing.
+             * @experimental
              */
             syntheticDelays?: string[];
             /**
              * Configuration for memory dump triggers. Used only when "memory-infra" category is enabled.
+             * @experimental
              */
             memoryDumpConfig?: MemoryDumpConfig;
         }
@@ -18353,11 +19078,13 @@ export namespace Protocol {
         /**
          * Data format of a trace. Can be either the legacy JSON format or the
          * protocol buffer format. Note that the JSON format will be deprecated soon.
+         * @experimental
          */
         export type StreamFormat = ('json' | 'proto');
 
         /**
          * Compression type to use for traces returned via streams.
+         * @experimental
          */
         export type StreamCompression = ('none' | 'gzip');
 
@@ -18365,6 +19092,7 @@ export namespace Protocol {
          * Details exposed when memory request explicitly declared.
          * Keep consistent with memory_dump_request_args.h and
          * memory_instrumentation.mojom
+         * @experimental
          */
         export type MemoryDumpLevelOfDetail = ('background' | 'light' | 'detailed');
 
@@ -18374,6 +19102,7 @@ export namespace Protocol {
          * supported on Chrome OS and uses the Perfetto system tracing service.
          * `auto` chooses `system` when the perfettoConfig provided to Tracing.start
          * specifies at least one non-Chrome data source; otherwise uses `chrome`.
+         * @experimental
          */
         export type TracingBackend = ('auto' | 'chrome' | 'system');
 
@@ -18421,19 +19150,24 @@ export namespace Protocol {
         export interface StartRequest {
             /**
              * Category/tag filter
+             * @deprecated
+             * @experimental
              */
             categories?: string;
             /**
              * Tracing options
+             * @deprecated
+             * @experimental
              */
             options?: string;
             /**
              * If set, the agent will issue bufferUsage events at this interval, specified in milliseconds
+             * @experimental
              */
             bufferUsageReportingInterval?: number;
             /**
              * Whether to report trace events as series of dataCollected events or to save trace to a
-             * stream (defaults to `ReportEvents`). (StartRequestTransferMode enum)
+             * stream (defaults to `ReportEvents`).
              */
             transferMode?: ('ReportEvents' | 'ReturnAsStream');
             /**
@@ -18444,6 +19178,7 @@ export namespace Protocol {
             /**
              * Compression format to use. This only applies when using `ReturnAsStream`
              * transfer mode (defaults to `none`)
+             * @experimental
              */
             streamCompression?: StreamCompression;
             traceConfig?: TraceConfig;
@@ -18451,14 +19186,19 @@ export namespace Protocol {
              * Base64-encoded serialized perfetto.protos.TraceConfig protobuf message
              * When specified, the parameters `categories`, `options`, `traceConfig`
              * are ignored. (Encoded as a base64 string when passed over JSON)
+             * @experimental
              */
             perfettoConfig?: string;
             /**
              * Backend type (defaults to `auto`)
+             * @experimental
              */
             tracingBackend?: TracingBackend;
         }
 
+        /**
+         * @experimental
+         */
         export interface BufferUsageEvent {
             /**
              * A number in range [0..1] that indicates the used size of event buffer as a fraction of its
@@ -18479,6 +19219,7 @@ export namespace Protocol {
         /**
          * Contains a bucket of collected trace events. When tracing is stopped collected events will be
          * sent as a sequence of dataCollected events followed by tracingComplete event.
+         * @experimental
          */
         export interface DataCollectedEvent {
             value: any[];
@@ -18562,7 +19303,7 @@ export namespace Protocol {
          */
         export interface AuthChallenge {
             /**
-             * Source of the authentication challenge. (AuthChallengeSource enum)
+             * Source of the authentication challenge.
              */
             source?: ('Server' | 'Proxy');
             /**
@@ -18592,7 +19333,7 @@ export namespace Protocol {
             /**
              * The decision on what to do in response to the authorization challenge.  Default means
              * deferring to the default behavior of the net stack, which will likely either the Cancel
-             * authentication or display a popup dialog box. (AuthChallengeResponseResponse enum)
+             * authentication or display a popup dialog box.
              */
             response: ('Default' | 'CancelAuth' | 'ProvideCredentials');
             /**
@@ -18690,6 +19431,7 @@ export namespace Protocol {
             headers?: HeaderEntry[];
             /**
              * If set, overrides response interception behavior for this request.
+             * @experimental
              */
             interceptResponse?: boolean;
         }
@@ -18812,6 +19554,7 @@ export namespace Protocol {
             /**
              * If the request is due to a redirect response from the server, the id of the request that
              * has caused the redirect.
+             * @experimental
              */
             redirectedRequestId?: RequestId;
         }
@@ -18849,6 +19592,7 @@ export namespace Protocol {
     /**
      * This domain allows inspection of Web Audio API.
      * https://webaudio.github.io/web-audio-api/
+     * @experimental
      */
     export namespace WebAudio {
 
@@ -19095,6 +19839,7 @@ export namespace Protocol {
     /**
      * This domain allows configuring virtual authenticators to test the WebAuthn
      * API.
+     * @experimental
      */
     export namespace WebAuthn {
 
@@ -19349,6 +20094,7 @@ export namespace Protocol {
 
     /**
      * This domain allows detailed inspection of media elements
+     * @experimental
      */
     export namespace Media {
 
@@ -19380,7 +20126,7 @@ export namespace Protocol {
              * representation of a media::PipelineStatus object. Soon however we're
              * going to be moving away from using PipelineStatus for errors and
              * introducing a new error type which should hopefully let us integrate
-             * the error log level into the PlayerError type. (PlayerMessageLevel enum)
+             * the error log level into the PlayerError type.
              */
             level: ('error' | 'warning' | 'info' | 'debug');
             message: string;
@@ -19480,6 +20226,9 @@ export namespace Protocol {
         }
     }
 
+    /**
+     * @experimental
+     */
     export namespace DeviceAccess {
 
         /**
@@ -19522,6 +20271,9 @@ export namespace Protocol {
         }
     }
 
+    /**
+     * @experimental
+     */
     export namespace Preload {
 
         /**
@@ -19570,6 +20322,7 @@ export namespace Protocol {
             errorType?: RuleSetErrorType;
             /**
              * TODO(https://crbug.com/1425354): Replace this property with structured error.
+             * @deprecated
              */
             errorMessage?: string;
         }
@@ -19719,6 +20472,7 @@ export namespace Protocol {
 
     /**
      * This domain allows interacting with the FedCM dialog.
+     * @experimental
      */
     export namespace FedCm {
 
@@ -19815,6 +20569,7 @@ export namespace Protocol {
 
     /**
      * This domain allows interacting with the browser to control PWAs.
+     * @experimental
      */
     export namespace PWA {
 
@@ -19920,6 +20675,7 @@ export namespace Protocol {
     /**
      * This domain allows configuring virtual Bluetooth devices to test
      * the web-bluetooth API.
+     * @experimental
      */
     export namespace BluetoothEmulation {
 


### PR DESCRIPTION
Provides more information to users of the types, that way you can use tools to find all deprecation like 
[EsLint no-deprecated](https://typescript-eslint.io/rules/no-deprecated/) to easily find things that may need to be changed.