### PR TITLE
Make the cookie expires value optional

### DIFF
--- a/json/browser_protocol.json
+++ b/json/browser_protocol.json
@@ -14160,6 +14160,7 @@
                         {
                             "name": "expires",
                             "description": "Cookie expiration date as the number of seconds since the UNIX epoch.",
+                            "optional": true,
                             "type": "number"
                         },
                         {


### PR DESCRIPTION
MDN Web Docs specify:
"If unspecified, the cookie becomes a session cookie. A session finishes when the client shuts down,
after which the session cookie is removed."