### PR TITLE
chore: disallow blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/stop--file-a-report-or-feature-request-on-crbug-com.md
+++ b/.github/ISSUE_TEMPLATE/stop--file-a-report-or-feature-request-on-crbug-com.md
@@ -4,11 +4,10 @@ about: Bug reports regarding the type definitions of CDP
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
-:warning:
-This repository is related to Chrome DevTools Protocol, but does not track issues regarding its definition or implementation.
-If you want to file an issue for the Chrome DevTools Protocol, please open an issue on https://crbug.com under [`component: Platform>DevTools>Platform`](https://bugs.chromium.org/p/chromium/issues/entry?components=Platform%3EDevTools%3EPlatform).
+> [!WARNING]
+> This repository is related to Chrome DevTools Protocol, but does not track issues regarding its definition or implementation.
+> If you want to file an issue for the Chrome DevTools Protocol, please open an issue on https://crbug.com under component: [ Chromium > Platform > DevTools](https://crbug.com/new?component=1457055).
 
-This repository only hosts issues regarding the type definitions of CDP.
+This repository only hosts issues regarding the TypeScript type definitions of CDP.


### PR DESCRIPTION
This will force the use of the provided template, which hopefully should prevent users.
Also update the template so that it up to date.