### PR TITLE
chore: work around Node.js 22 / npm issue

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -20,7 +20,9 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
       - name: Update npm
-        run: npm install -g npm@latest
+        run: |
+          npm install -g npm@~11.10.0 # Workaround for https://github.com/npm/cli/issues/9151.
+          npm install -g npm@latest
       - name: Publish
         run: |
           npm publish --provenance --access public

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -19,10 +19,6 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
-      - name: Update npm
-        run: |
-          npm install -g npm@~11.10.0 # Workaround for https://github.com/npm/cli/issues/9151.
-          npm install -g npm@latest
       - name: Publish
         run: |
           npm publish --provenance --access public


### PR DESCRIPTION
This patch temporarily adds an extra `npm install -g npm` to ensure an incremental upgrade, since direct upgrades to `npm@latest` are broken in npm 10.9.7 (which is bundled with Node.js 22.22.2).

Running `npm install -g npm@latest` on Node.js 22.22.2 (which bundles npm 10.9.7) fails with `MODULE_NOT_FOUND: promise-retry`. This happens because npm 11.12.0 removed `promise-retry` from its bundle (in favor of `@gar/promise-retry`). During the self-upgrade, the reify step deletes `promise-retry` from disk, and then the still-running 10.x process hits a lazy `require('promise-retry')` in `_linkBins` and blows up.

The root cause has already been fixed upstream (https://github.com/npm/cli/pull/9152) and released on npm 10.9.8. However, we still need the workaround until a Node.js 22 patch release ships with npm ≥ 10.9.8.